### PR TITLE
Add lint step to pre-commit script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
-# 1. Build the contracts
-# 2. Stage build output
-# 3. Lint and stage style improvements
-yarn build && npx lint-staged
+# 1. Run lint check
+# 2. Build the contracts
+# 3. Stage build output
+# 4. Lint and stage style improvements
+yarn lint:check && yarn build && npx lint-staged

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -167,7 +167,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     _circle = circles[_id];
 
     if (_isDecommissioned(_circle)) revert NotCommissioned();
-
   }
 
   /**

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -73,12 +73,12 @@ interface ISavingCircles {
                             VIEW
   //////////////////////////////////////////////////////////////*/
 
-  function getCircle(uint256 id) external view returns (Circle memory);
-  function getCircles(uint256[] calldata ids) external view returns (Circle[] memory);
-  function getMemberCircles(address member) external view returns (uint256[] memory);
-  function getMemberBalances(uint256 id) external view returns (address[] memory, uint256[] memory);
-  function checkMemberships(address member, uint256[] calldata ids) external view returns (bool[] memory);
-  function isTokenAllowed(address token) external view returns (bool);
-  function isWithdrawable(uint256 id) external view returns (bool);
-  function withdrawableBy(uint256 id) external view returns (address);
+  function getCircle(uint256 id) external view returns (Circle memory circle);
+  function getCircles(uint256[] calldata ids) external view returns (Circle[] memory circles);
+  function getMemberCircles(address member) external view returns (uint256[] memory circles);
+  function getMemberBalances(uint256 id) external view returns (address[] memory members, uint256[] memory balances);
+  function checkMemberships(address member, uint256[] calldata ids) external view returns (bool[] memory memberships);
+  function isTokenAllowed(address token) external view returns (bool allowed);
+  function isWithdrawable(uint256 id) external view returns (bool withdrawable);
+  function withdrawableBy(uint256 id) external view returns (address withdrawableBy);
 }

--- a/test/.solhint.json
+++ b/test/.solhint.json
@@ -11,7 +11,6 @@
     "no-global-import": "off",
     "max-states-count": "off",
     "ordering": "off",
-    "one-contract-per-file": "off",
-    "func-name-mixedcase": "off"
+    "one-contract-per-file": "off"
   }
 }

--- a/test/integration/SavingCircles.t.sol
+++ b/test/integration/SavingCircles.t.sol
@@ -2,14 +2,9 @@
 pragma solidity ^0.8.28;
 
 import {OwnableUpgradeable} from '@openzeppelin-upgradeable/access/OwnableUpgradeable.sol';
-import {ProxyAdmin} from '@openzeppelin/proxy/transparent/ProxyAdmin.sol';
-import {TransparentUpgradeableProxy} from '@openzeppelin/proxy/transparent/TransparentUpgradeableProxy.sol';
-import {Test} from 'forge-std/Test.sol';
 
 import {ISavingCircles} from '../../src/interfaces/ISavingCircles.sol';
 import {IntegrationBase} from 'test/integration/IntegrationBase.sol';
-
-/* solhint-disable func-name-mixedcase */
 
 contract SavingCirclesIntegration is IntegrationBase {
   function setUp() public override {

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -10,8 +10,6 @@ import {Test} from 'forge-std/Test.sol';
 import {MockERC20} from '../mocks/MockERC20.sol';
 import {ISavingCircles, SavingCircles} from 'contracts/SavingCircles.sol';
 
-/* solhint-disable func-name-mixedcase */
-
 contract SavingCirclesUnit is Test {
   uint256 public constant BASE_CURRENT_INDEX = 0;
   uint256 public constant DEPOSIT_AMOUNT = 1 ether;


### PR DESCRIPTION
Adds a `yarn lint:check` step to the pre-commit script so that changes that break the linter check cannot be committed.

This was branched off `fix-linter-errors` branch for https://github.com/BreadchainCoop/saving-circles/pull/24, so that should be merged in first. This is an optional change, so wanted to give it the opportunity to be reviewed separate from those changes.