### PR TITLE
Documentation cleanup

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -29,14 +29,19 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     _disableInitializers();
   }
 
+  /// @inheritdoc ISavingCircles
   function initialize(address _owner) external override initializer {
     __Ownable_init_unchained(_owner);
   }
 
-  /**
-   * @notice Create a new saving circle
-   * @param _circle A new saving circle
-   */
+  /// @inheritdoc ISavingCircles
+  function setTokenAllowed(address _token, bool _allowed) external override onlyOwner {
+    allowedTokens[_token] = _allowed;
+
+    emit TokenAllowed(_token, _allowed);
+  }
+
+  /// @inheritdoc ISavingCircles
   function create(Circle memory _circle) external override returns (uint256 _id) {
     _id = nextId++;
 
@@ -64,59 +69,27 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     return _id;
   }
 
-  /**
-   * @notice Make a deposit into a specified circle
-   * @param _id Identifier of the circle
-   * @param _value Amount of the token to deposit
-   */
+  /// @inheritdoc ISavingCircles
   function deposit(uint256 _id, uint256 _value) external override nonReentrant {
     _deposit(_id, _value, msg.sender);
   }
 
-  /**
-   * @notice Make a deposit on behalf of another member
-   * @param _id Identifier of the circle
-   * @param _value Amount of the token to deposit
-   * @param _member Address to make a deposit for
-   */
+  /// @inheritdoc ISavingCircles
   function depositFor(uint256 _id, uint256 _value, address _member) external override nonReentrant {
     _deposit(_id, _value, _member);
   }
 
-  /**
-   * @notice Make a withdrawal from a specified circle
-   * @param _id Identifier of the circle
-   */
+  /// @inheritdoc ISavingCircles
   function withdraw(uint256 _id) external override nonReentrant {
     _withdraw(_id, msg.sender);
   }
 
-  /**
-   * @notice Make a withdrawal from a specified circle on behalf of another member
-   * @param _id Identifier of the circle
-   * @param _member Address of the member to make a withdrawal for
-   */
+  /// @inheritdoc ISavingCircles
   function withdrawFor(uint256 _id, address _member) external override nonReentrant {
     _withdraw(_id, _member);
   }
 
-  /**
-   * @notice Set if a token can be used for saving circles
-   * @param _token Token to update the status of
-   * @param _allowed Can be used for saving circles
-   */
-  function setTokenAllowed(address _token, bool _allowed) external override onlyOwner {
-    allowedTokens[_token] = _allowed;
-
-    emit TokenAllowed(_token, _allowed);
-  }
-
-  /**
-   * @notice Decommission an existing saving circle
-   * @dev Returns all deposits to members
-   * @dev No access control required because funds are stuck until a circle is decommissioned
-   * @param _id Identifier of the circle
-   */
+  /// @inheritdoc ISavingCircles
   function decommission(uint256 _id) external override nonReentrant {
     Circle storage _circle = circles[_id];
 
@@ -150,29 +123,14 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     emit CircleDecommissioned(_id);
   }
 
-  /**
-   * @notice Return if a token is allowed to be used for saving circles
-   * @param _token Address of a token
-   * @return bool Token allowed
-   */
-  function isTokenAllowed(address _token) external view override returns (bool) {
-    return allowedTokens[_token];
-  }
-
-  /**
-   * @notice Return the info of a specified saving circle
-   * @param _id Identifier of the circle
-   */
+  /// @inheritdoc ISavingCircles
   function getCircle(uint256 _id) external view override returns (Circle memory _circle) {
     _circle = circles[_id];
 
     if (_isDecommissioned(_circle)) revert NotCommissioned();
   }
 
-  /**
-   * @notice Get multiple circles in a single call
-   * @param _ids Array of circle IDs to fetch
-   */
+  /// @inheritdoc ISavingCircles
   function getCircles(uint256[] calldata _ids) external view returns (Circle[] memory _circles) {
     _circles = new Circle[](_ids.length);
 
@@ -181,21 +139,12 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     }
   }
 
-  /**
-   * @notice Get all circles for a specific member
-   * @param _member Address of the member
-   * @return _ids Array of circle IDs the member belongs to
-   */
+  /// @inheritdoc ISavingCircles
   function getMemberCircles(address _member) external view returns (uint256[] memory _ids) {
     return memberCircles[_member];
   }
 
-  /**
-   * @notice Return the balances of the members of a specified saving circle
-   * @param _id Identifier of the circle
-   * @return _members Members of the specified saving circle
-   * @return _balances Corresponding balances of the members of the circle
-   */
+  /// @inheritdoc ISavingCircles
   function getMemberBalances(uint256 _id)
     external
     view
@@ -214,12 +163,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     return (_circle.members, _balances);
   }
 
-  /**
-   * @notice Check membership status for multiple circles
-   * @param _member Address to check
-   * @param _ids Array of circle IDs to check
-   * @return _statuses Array of boolean membership statuses
-   */
+  /// @inheritdoc ISavingCircles
   function checkMemberships(address _member, uint256[] calldata _ids) external view returns (bool[] memory _statuses) {
     _statuses = new bool[](_ids.length);
 
@@ -230,26 +174,23 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     return _statuses;
   }
 
-  /**
-   * @notice Return the member address which is currently able to withdraw from a specified circle
-   * @param _id Identifier of the circle
-   * @return address Member that is currently able to withdraw from the circle
-   */
+  /// @inheritdoc ISavingCircles
+  function isTokenAllowed(address _token) external view override returns (bool) {
+    return allowedTokens[_token];
+  }
+
+  /// @inheritdoc ISavingCircles
+  function isWithdrawable(uint256 _id) external view override returns (bool) {
+    return _withdrawable(_id);
+  }
+
+  /// @inheritdoc ISavingCircles
   function withdrawableBy(uint256 _id) external view override returns (address) {
     Circle memory _circle = circles[_id];
 
     if (_isDecommissioned(_circle)) revert NotCommissioned();
 
     return _circle.members[_circle.currentIndex];
-  }
-
-  /**
-   * @notice Return if a circle can currently be withdrawn from
-   * @param _id Identifier of the circle
-   * @return bool If the circle is able to be withdrawn from
-   */
-  function isWithdrawable(uint256 _id) external view override returns (bool) {
-    return _withdrawable(_id);
   }
 
   /**

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -66,7 +66,7 @@ interface ISavingCircles {
   event TokenAllowed(address indexed token, bool indexed allowed);
 
   /**
-   * @notice Thrown when a member attempts to deposit funds into a circle
+   * @notice Thrown when a member attempts to redundantly deposit funds into a circle
    */
   error AlreadyDeposited();
 

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -2,10 +2,17 @@
 pragma solidity ^0.8.28;
 
 interface ISavingCircles {
-  /*///////////////////////////////////////////////////////////////
-                            STRUCTS
-  //////////////////////////////////////////////////////////////*/
-
+  /**
+   * @notice A struct representing a saving circle
+   * @param owner The owner of the circle
+   * @param members The members of the circle
+   * @param currentIndex The current index of the circle
+   * @param depositAmount The deposit amount of the circle
+   * @param token The token of the circle
+   * @param depositInterval The deposit interval of the circle
+   * @param circleStart The start time of the circle
+   * @param maxDeposits The maximum number of deposits for the circle
+   */
   struct Circle {
     address owner;
     address[] members;
@@ -17,68 +24,266 @@ interface ISavingCircles {
     uint256 maxDeposits;
   }
 
-  /*///////////////////////////////////////////////////////////////
-                            EVENTS
-  //////////////////////////////////////////////////////////////*/
-
+  /**
+   * @notice Emitted when a circle is created
+   * @param id The ID of the circle
+   * @param members The members of the circle
+   * @param token The token of the circle
+   * @param depositAmount The deposit amount of the circle
+   * @param depositInterval The deposit interval of the circle
+   */
   event CircleCreated(
     uint256 indexed id, address[] members, address token, uint256 depositAmount, uint256 depositInterval
   );
+
+  /**
+   * @notice Emitted when a circle is decommissioned
+   * @param id The ID of the circle
+   */
   event CircleDecommissioned(uint256 indexed id);
+
+  /**
+   * @notice Emitted when a member deposits funds into a circle
+   * @param id The ID of the circle
+   * @param member The address of the member
+   * @param amount The amount of funds deposited
+   */
   event FundsDeposited(uint256 indexed id, address indexed member, uint256 amount);
+
+  /**
+   * @notice Emitted when a member withdraws funds from a circle
+   * @param id The ID of the circle
+   * @param member The address of the member
+   * @param amount The amount of funds withdrawn
+   */
   event FundsWithdrawn(uint256 indexed id, address indexed member, uint256 amount);
+
+  /**
+   * @notice Emitted when a token is allowed
+   * @param token The address of the token
+   * @param allowed Whether the token is allowed
+   */
   event TokenAllowed(address indexed token, bool indexed allowed);
 
-  /*///////////////////////////////////////////////////////////////
-                            ERRORS
-  //////////////////////////////////////////////////////////////*/
-
+  /**
+   * @notice Thrown when a member attempts to deposit funds into a circle
+   */
   error AlreadyDeposited();
+
+  /**
+   * @notice Thrown when a circle already exists
+   */
   error AlreadyExists();
+
+  /**
+   * @notice Thrown when a deposit is invalid
+   */
   error InvalidDeposit();
+
+  /**
+   * @notice Thrown when a circle is invalid
+   */
   error InvalidCircle();
+
+  /**
+   * @notice Thrown when a circle is not commissioned
+   */
   error NotCommissioned();
+
+  /**
+   * @notice Thrown when a member is not a member of a circle
+   */
   error NotMember();
+
+  /**
+   * @notice Thrown when a circle is not decommissionable
+   */
   error NotDecommissionable();
+
+  /**
+   * @notice Thrown when a circle is not withdrawable
+   */
   error NotWithdrawable();
+
+  /**
+   * @notice Thrown when a transfer fails
+   */
   error TransferFailed();
+
+  /**
+   * @notice Thrown when a deposit window is closed
+   */
   error DepositWindowClosed();
+
+  /**
+   * @notice Thrown when a circle has expired
+   */
   error CircleExpired();
+
+  /**
+   * @notice Thrown when a deposit amount is exceeded
+   */
   error ExceedsDepositAmount();
+
+  /**
+   * @notice Thrown when a deposit is made before the circle starts
+   */
   error DepositBeforeCircleStart();
+
+  /**
+   * @notice Thrown when a token is not allowed
+   */
   error TokenNotAllowed();
+
+  /**
+   * @notice Thrown when a deposit interval is invalid
+   */
   error InvalidDepositInterval();
+
+  /**
+   * @notice Thrown when a deposit amount is invalid
+   */
   error InvalidDepositAmount();
+
+  /**
+   * @notice Thrown when a max deposits is invalid
+   */
   error InvalidMaxDeposits();
+
+  /**
+   * @notice Thrown when a circle start time is invalid
+   */
   error InvalidCircleStartTime();
+
+  /**
+   * @notice Thrown when a current index is invalid
+   */
   error InvalidCurrentIndex();
+
+  /**
+   * @notice Thrown when a owner is invalid
+   */
   error InvalidOwner();
+
+  /**
+   * @notice Thrown when a member count is invalid
+   */
   error InvalidMemberCount();
+
+  /**
+   * @notice Thrown when a member address is invalid
+   */
   error InvalidMemberAddress();
 
-  /*///////////////////////////////////////////////////////////////
-                            VIEW
-  //////////////////////////////////////////////////////////////*/
-
+  /**
+   * @notice Initialize the contract
+   * @param owner The owner of the contract
+   */
   function initialize(address owner) external;
+
+  /**
+   * @notice Set a token allowed
+   * @param token The address of the token
+   * @param allowed Whether the token is allowed
+   */
   function setTokenAllowed(address token, bool allowed) external;
+
+  /**
+   * @notice Create a circle
+   * @param circle The circle
+   * @return id The ID of the circle
+   */
   function create(Circle memory circle) external returns (uint256);
+
+  /**
+   * @notice Deposit funds into a circle
+   * @param id The ID of the circle
+   * @param value The amount of funds to deposit
+   */
   function deposit(uint256 id, uint256 value) external;
+
+  /**
+   * @notice Deposit funds into a circle for a member
+   * @param id The ID of the circle
+   * @param value The amount of funds to deposit
+   * @param member The address of the member
+   */
   function depositFor(uint256 id, uint256 value, address member) external;
+
+  /**
+   * @notice Withdraw funds from a circle
+   * @param id The ID of the circle
+   */
   function withdraw(uint256 id) external;
+
+  /**
+   * @notice Withdraw funds from a circle for a member
+   * @param id The ID of the circle
+   * @param member The address of the member
+   */
   function withdrawFor(uint256 id, address member) external;
+
+  /**
+   * @notice Decommission a circle
+   * @param id The ID of the circle
+   */
   function decommission(uint256 id) external;
 
-  /*///////////////////////////////////////////////////////////////
-                            VIEW
-  //////////////////////////////////////////////////////////////*/
-
+  /**
+   * @notice Get a single circle
+   * @param id The ID of the circle
+   * @return circle The circle
+   */
   function getCircle(uint256 id) external view returns (Circle memory circle);
+
+  /**
+   * @notice Get multiple circles
+   * @param ids The IDs of the circles
+   * @return circles The circles
+   */
   function getCircles(uint256[] calldata ids) external view returns (Circle[] memory circles);
+
+  /**
+   * @notice Get all circles for a member
+   * @param member The address of the member
+   * @return circles The circles
+   */
   function getMemberCircles(address member) external view returns (uint256[] memory circles);
+
+  /**
+   * @notice Get the balances of the members of a circle
+   * @param id The ID of the circle
+   * @return members The members of the circle
+   * @return balances The balances of the members of the circle
+   */
   function getMemberBalances(uint256 id) external view returns (address[] memory members, uint256[] memory balances);
+
+  /**
+   * @notice Check if a member is a member of a circle
+   * @param member The address of the member
+   * @param ids The IDs of the circles
+   * @return memberships The memberships of the member
+   */
   function checkMemberships(address member, uint256[] calldata ids) external view returns (bool[] memory memberships);
+
+  /**
+   * @notice Check if a token is allowed
+   * @param token The address of the token
+   * @return allowed Whether the token is allowed
+   */
   function isTokenAllowed(address token) external view returns (bool allowed);
+
+  /**
+   * @notice Check if a circle is withdrawable
+   * @param id The ID of the circle
+   * @return withdrawable Whether the circle is withdrawable
+   */
   function isWithdrawable(uint256 id) external view returns (bool withdrawable);
+
+  /**
+   * @notice Get the address of the withdrawable by
+   * @param id The ID of the circle
+   * @return withdrawableBy The address of the withdrawable by
+   */
   function withdrawableBy(uint256 id) external view returns (address withdrawableBy);
 }


### PR DESCRIPTION
Move Natspec comments into the interface and do some basic cleanup. The section comments (STRUCTS, EVENT, VIEW) were removed because the linter automatically reformats them. It makes it messy and unpredictable.

Branched off `fix-linter-errors` so please review/merge https://github.com/BreadchainCoop/saving-circles/pull/24 first.