### PR TITLE
fix: optimize gas usage in create() function (Issue #9)

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -69,7 +69,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     if (_circle.owner == address(0)) revert InvalidOwner();
     if (_circle.members.length < MINIMUM_MEMBERS) revert InvalidMemberCount();
 
-    for (uint256 i = 0; i < _circle.members.length; i++) {
+    uint256 _circleMembersLength = _circle.members.length;
+    for (uint256 i = 0; i < _circleMembersLength; i++) {
       address _member = _circle.members[i];
       if (_member == address(0)) revert InvalidMemberAddress();
       isMember[_id][_member] = true;


### PR DESCRIPTION
## Summary
- Cached `_circle.members.length` in the `create()` function to avoid multiple SLOAD operations
- This completes the gas optimization efforts for Issue #9 that were partially addressed in previous commits

## Test plan
- [ ] Run existing test suite to ensure no regressions
- [ ] Verify contract deployment and circle creation still works as expected
- [ ] Check gas usage reduction in create() function when creating circles with multiple members

🤖 Generated with [Claude Code](https://claude.ai/code)