### PR TITLE
fix: make withdrawFor permissionless by moving membership check _withdraw to withdraw()

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -94,7 +94,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
   }
 
   /// @inheritdoc ISavingCircles
-  function withdraw(uint256 _id) external override nonReentrant {
+  function withdraw(uint256 _id) external override nonReentrant onlyMember(_id, msg.sender) {
     _withdraw(_id, msg.sender);
   }
 
@@ -210,9 +210,9 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
 
   /**
    * @dev Make a withdrawal from a specified circle
-   *      A withdrawal must be made by a member of the circle, even if it is for another member.
+   *      Permissionless: anyone can trigger the payout for the member whose turn it is to withdraw
    */
-  function _withdraw(uint256 _id, address _member) internal onlyMember(_id, msg.sender) {
+  function _withdraw(uint256 _id, address _member) internal {
     Circle storage _circle = circles[_id];
 
     if (!_withdrawable(_id)) revert NotWithdrawable();

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -628,9 +628,12 @@ contract SavingCirclesUnit is Test {
     // Wait for withdrawal time
     vm.warp(block.timestamp + DEPOSIT_INTERVAL);
 
-    vm.prank(STRANGER); // Non-member trying to call withdrawFor
-    vm.expectRevert(ISavingCircles.NotMember.selector);
+    // Non-member can now trigger withdrawFor successfully
+    uint256 aliceBefore = token.balanceOf(alice);
+    vm.prank(STRANGER);
     savingCircles.withdrawFor(baseCircleId, alice);
+
+    assertEq(token.balanceOf(alice), aliceBefore + (DEPOSIT_AMOUNT * members.length));
   }
 
   // ============ Edge Case Tests for Decommission ============


### PR DESCRIPTION
Closes #55 