### PR TITLE
fix: optimize start() to use single loop for member filtering

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -87,23 +87,22 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable {
     Circle storage _circle = circles[_id];
     if (isActive[_id]) revert AlreadyActive();
     if (msg.sender != _circle.owner) revert NotOwner();
+    // Single pass: count and collect non-null members
+    address[] memory tempMembers = new address[](_circle.members.length);
     uint256 membersCount = 0;
     for (uint256 i = 0; i < _circle.members.length; i++) {
-      if (_circle.members[i] != address(0)) {
+      address member = _circle.members[i];
+      if (member != address(0)) {
+        tempMembers[membersCount] = member;
         membersCount++;
       }
     }
     if (membersCount < MINIMUM_MEMBERS) revert InvalidMemberCount();
 
+    // Copy to correctly sized array
     address[] memory members = new address[](membersCount);
-    uint256 memberIndex = 0;
-    for (uint256 i = 0; i < _circle.members.length; i++) {
-      address member = _circle.members[i];
-      if (member == address(0)) {
-        continue;
-      }
-      members[memberIndex] = member;
-      memberIndex++;
+    for (uint256 i = 0; i < membersCount; i++) {
+      members[i] = tempMembers[i];
     }
     circles[_id].members = members;
 


### PR DESCRIPTION
## Summary
- Refactored the `start()` function to eliminate the double loop when filtering null members
- Now uses a single pass to collect non-null members into a temp array, then copies to the correctly sized final array
- Reduces gas costs by only iterating through the full members array once

## Explanation

**Before:** The code had two separate loops over `_circle.members`:
1. First loop counted non-null members to determine the array size
2. Second loop copied non-null members to the new array

**After:** Single loop approach:
1. Allocate a temp array sized to the max possible members
2. In one pass, collect non-null members and count them
3. Copy only `membersCount` elements to the final correctly-sized array

The second copy loop now iterates only `membersCount` times (the actual valid members) instead of the full array length, saving gas when there are null entries.

## Test plan
- [x] Verify existing tests pass
- [ ] Check gas usage improvement in start() function