### PR TITLE
Deploy helpers alongside SavingCircles proxy + fix solhint ordering

### DIFF
--- a/script/Common.sol
+++ b/script/Common.sol
@@ -41,7 +41,7 @@ contract Common is Script {
       abi.encodeWithSelector(SavingCircles.initialize.selector, _admin)
     );
 
-    // Deploy helpers
+    // Deploy auxiliary contracts that reference the SavingCircles proxy
     new DelegatedSavingCircles(address(proxy));
     new SavingCirclesViewer(address(proxy));
 

--- a/script/Common.sol
+++ b/script/Common.sol
@@ -11,7 +11,7 @@ import {SavingCirclesViewer} from '../src/contracts/SavingCirclesViewer.sol';
 
 /**
  * @title Common Contract
- * @author Bread
+ * @author Bread Cooperative
  * @notice This contract is used to deploy an upgradeable Saving Circles contract
  * @dev This contract is intended for use in Scripts and Integration Tests
  */

--- a/script/Common.sol
+++ b/script/Common.sol
@@ -35,11 +35,10 @@ contract Common is Script {
   }
 
   function _deployContracts(address _admin) internal returns (TransparentUpgradeableProxy) {
-    SavingCircles impl = _deploySavingCircles();
-    ProxyAdmin proxyAdmin = _deployProxyAdmin(_admin);
-
     TransparentUpgradeableProxy proxy = _deployTransparentProxy(
-      address(impl), address(proxyAdmin), abi.encodeWithSelector(SavingCircles.initialize.selector, _admin)
+      address(_deploySavingCircles()),
+      address(_deployProxyAdmin(_admin)),
+      abi.encodeWithSelector(SavingCircles.initialize.selector, _admin)
     );
 
     // Deploy helpers

--- a/script/Common.sol
+++ b/script/Common.sol
@@ -5,11 +5,13 @@ import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.s
 import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {Script} from 'forge-std/Script.sol';
 
+import {DelegatedSavingCircles} from '../src/contracts/DelegatedSavingCircles.sol';
 import {SavingCircles} from '../src/contracts/SavingCircles.sol';
+import {SavingCirclesViewer} from '../src/contracts/SavingCirclesViewer.sol';
 
 /**
  * @title Common Contract
- * @author Breadchain
+ * @author Bread
  * @notice This contract is used to deploy an upgradeable Saving Circles contract
  * @dev This contract is intended for use in Scripts and Integration Tests
  */
@@ -33,10 +35,17 @@ contract Common is Script {
   }
 
   function _deployContracts(address _admin) internal returns (TransparentUpgradeableProxy) {
-    return _deployTransparentProxy(
-      address(_deploySavingCircles()),
-      address(_deployProxyAdmin(_admin)),
-      abi.encodeWithSelector(SavingCircles.initialize.selector, _admin)
+    SavingCircles impl = _deploySavingCircles();
+    ProxyAdmin proxyAdmin = _deployProxyAdmin(_admin);
+
+    TransparentUpgradeableProxy proxy = _deployTransparentProxy(
+      address(impl), address(proxyAdmin), abi.encodeWithSelector(SavingCircles.initialize.selector, _admin)
     );
+
+    // Deploy helpers
+    new DelegatedSavingCircles(address(proxy));
+    new SavingCirclesViewer(address(proxy));
+
+    return proxy;
   }
 }

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -347,13 +347,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable, E
   }
 
   /**
-   * @dev Return if a specified circle is decommissioned by checking if an owner is set
-   */
-  function _isDecommissioned(Circle memory _circle) internal pure returns (bool) {
-    return _circle.owner == address(0);
-  }
-
-  /**
    * @dev Return if a specified circle is decommissionable
    *      To be considered decommissionable, the circle must have passed its deposit window
    *      and all members must have made their deposits for the current round.
@@ -377,6 +370,13 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable, E
     if (!hasIncompleteDeposits) decommissionable = false;
 
     return decommissionable;
+  }
+
+  /**
+   * @dev Return if a specified circle is decommissioned by checking if an owner is set
+   */
+  function _isDecommissioned(Circle memory _circle) internal pure returns (bool) {
+    return _circle.owner == address(0);
   }
 
   /**


### PR DESCRIPTION
- Update deploy script to deploy helper contracts:
  - `DelegatedSavingCircles` (constructor points to SavingCircles proxy)
  - `SavingCirclesViewer` (constructor points to SavingCircles proxy)
- Keep `SavingCircles` deployed as implementation + TransparentUpgradeableProxy + ProxyAdmin (unchanged pattern)


## Deployment

| Item | Value |
|---|---|
| Network | Gnosis (chainId 100) |
| Proxy (frontend) | `0x80979edbd8a350b3156cd607dc3e8fcb9ff02ecf` |
| Implementation | `0x7ed0b66b9d42652b8c4090ad0ff249250bec5d41` |
| DelegatedSavingCircles | `0xde30ea26536a3aae2dbc07d3eb4bd6eb8e820c06` |
| SavingCirclesViewer | `0xc4f18d8e2681e92647c5efa406e1bc8df8acafc0` |
| BREAD allowed | `0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3` |
