### PR TITLE
fix: gate withdrawals to final-day window and update tests

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -326,13 +326,16 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable, E
 
   /**
    * @dev Return if a specified circle is withdrawable
-   *      To be considered withdrawable, enough time must have passed since the deposit interval started
-   *      and all members must have made a deposit.
+   *      To be considered withdrawable, the current deposit window must be within its final day
+   *      (last 24 hours of the current round) and all members must have made a deposit.
    */
   function _withdrawable(uint256 _id) internal view onlyCommissioned(_id) returns (bool) {
     Circle memory _circle = circles[_id];
 
-    if (block.timestamp < _circle.effectiveCircleStartTime + (_circle.depositInterval * _circle.currentIndex)) {
+    uint256 windowEnd = _circle.effectiveCircleStartTime + (_circle.depositInterval * (_circle.currentIndex + 1));
+    uint256 lastDayStart = windowEnd - 1 days;
+
+    if (block.timestamp < lastDayStart) {
       return false;
     }
     address[] memory members = circleMembers[_id];

--- a/test/integration/SavingCircles.t.sol
+++ b/test/integration/SavingCircles.t.sol
@@ -89,6 +89,9 @@ contract SavingCirclesIntegration is IntegrationBase {
     vm.prank(carol);
     circle.deposit(baseCircleId, DEPOSIT_AMOUNT);
 
+    // Move into last day of round 0
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL - 1 days);
+
     // First member withdraws
     uint256 balanceBefore = token.balanceOf(alice);
     vm.prank(alice);
@@ -103,14 +106,17 @@ contract SavingCirclesIntegration is IntegrationBase {
     vm.expectRevert(ISavingCircles.NotWithdrawable.selector);
     circle.withdraw(baseCircleId);
 
-    // Wait for interval (need to wait for index 1's interval)
-    vm.warp(block.timestamp + DEPOSIT_INTERVAL);
+    // Move to start of round 1 window
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
     vm.prank(alice);
     circle.deposit(baseCircleId, DEPOSIT_AMOUNT);
     vm.prank(bob);
     circle.deposit(baseCircleId, DEPOSIT_AMOUNT);
     vm.prank(carol);
     circle.deposit(baseCircleId, DEPOSIT_AMOUNT);
+
+    // Move into last day of round 1
+    vm.warp(baseCircleStart + (2 * DEPOSIT_INTERVAL) - 1 days);
 
     // Bob should be able to withdraw
     vm.prank(bob);
@@ -130,6 +136,9 @@ contract SavingCirclesIntegration is IntegrationBase {
     vm.prank(carol);
     circle.deposit(baseCircleId, DEPOSIT_AMOUNT);
 
+    // Move into last day of round 0
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL - 1 days);
+
     // Bob tries to withdraw for Alice (who is first in line)
     uint256 balanceBefore = token.balanceOf(alice);
     vm.prank(bob);
@@ -144,8 +153,8 @@ contract SavingCirclesIntegration is IntegrationBase {
     vm.expectRevert(ISavingCircles.NotWithdrawable.selector);
     circle.withdrawFor(baseCircleId, bob);
 
-    // Wait for interval (need to wait for index 1's interval)
-    vm.warp(block.timestamp + DEPOSIT_INTERVAL);
+    // Move to start of round 1 window
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
 
     // New round of deposits
     vm.prank(alice);
@@ -154,6 +163,9 @@ contract SavingCirclesIntegration is IntegrationBase {
     circle.deposit(baseCircleId, DEPOSIT_AMOUNT);
     vm.prank(carol);
     circle.deposit(baseCircleId, DEPOSIT_AMOUNT);
+
+    // Move into last day of round 1
+    vm.warp(baseCircleStart + (2 * DEPOSIT_INTERVAL) - 1 days);
 
     // Alice withdraws for Bob (who is now next in line)
     balanceBefore = token.balanceOf(bob);

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -98,6 +98,31 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     return _createCircle(savingCircles, circle, inviteMembers, _ownerPrivateKey);
   }
 
+  function _createCircleWithInterval(uint256 _depositInterval) internal returns (uint256) {
+    ISavingCircles.Circle memory circle = _defaultCircle(alice, DEPOSIT_AMOUNT, _depositInterval, address(token));
+    return _createCircleWithMembers(savingCircles, circle, members, _alicePrivateKey);
+  }
+
+  function _depositFullRound(uint256 _circleId) internal {
+    vm.startPrank(alice);
+    token.mint(alice, DEPOSIT_AMOUNT);
+    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+    savingCircles.deposit(_circleId, DEPOSIT_AMOUNT);
+    vm.stopPrank();
+
+    vm.startPrank(bob);
+    token.mint(bob, DEPOSIT_AMOUNT);
+    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+    savingCircles.deposit(_circleId, DEPOSIT_AMOUNT);
+    vm.stopPrank();
+
+    vm.startPrank(carol);
+    token.mint(carol, DEPOSIT_AMOUNT);
+    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+    savingCircles.deposit(_circleId, DEPOSIT_AMOUNT);
+    vm.stopPrank();
+  }
+
   function test_SetTokenAllowedWhenCallerIsNotOwner() external {
     vm.prank(alice);
     vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, alice));
@@ -242,23 +267,7 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
 
   function test_WithdrawWhenParametersAreValid() external {
     // Complete deposits from all members
-    vm.startPrank(alice);
-    token.mint(alice, DEPOSIT_AMOUNT);
-    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
-    savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
-    vm.stopPrank();
-
-    vm.startPrank(bob);
-    token.mint(bob, DEPOSIT_AMOUNT);
-    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
-    savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
-    vm.stopPrank();
-
-    vm.startPrank(carol);
-    token.mint(carol, DEPOSIT_AMOUNT);
-    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
-    savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
-    vm.stopPrank();
+    _depositFullRound(baseCircleId);
 
     // Move time past first round
     vm.warp(block.timestamp + DEPOSIT_INTERVAL);
@@ -288,23 +297,7 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
 
   function test_WithdrawForWhenParametersAreValid() external {
     // Complete deposits from all members
-    vm.startPrank(alice);
-    token.mint(alice, DEPOSIT_AMOUNT);
-    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
-    savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
-    vm.stopPrank();
-
-    vm.startPrank(bob);
-    token.mint(bob, DEPOSIT_AMOUNT);
-    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
-    savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
-    vm.stopPrank();
-
-    vm.startPrank(carol);
-    token.mint(carol, DEPOSIT_AMOUNT);
-    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
-    savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
-    vm.stopPrank();
+    _depositFullRound(baseCircleId);
 
     // Move time past first round
     vm.warp(block.timestamp + DEPOSIT_INTERVAL);
@@ -516,6 +509,54 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     assertEq(started.effectiveCircleStartTime, expectedStart);
     address[] memory storedMembers = savingCircles.getCircleMembers(circleId);
     assertEq(started.circleEnd, expectedStart + (started.depositInterval * storedMembers.length));
+  }
+
+  function test_WithdrawableDuringLastDayOfCurrentRound() external {
+    uint256 interval = 7 days;
+    uint256 circleId = _createCircleWithInterval(interval);
+    uint256 startTime = savingCircles.getCircle(circleId).effectiveCircleStartTime;
+
+    _depositFullRound(circleId);
+
+    // 1 second before last day begins
+    vm.warp(startTime + interval - 1 days - 1);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotWithdrawable.selector));
+    savingCircles.withdraw(circleId);
+
+    // At last day start (last 24 hours of window)
+    vm.warp(startTime + interval - 1 days);
+    vm.prank(alice);
+    savingCircles.withdraw(circleId);
+  }
+
+  function test_WithdrawableDayAfterWindowEnds() external {
+    uint256 interval = 7 days;
+    uint256 circleId = _createCircleWithInterval(interval);
+    uint256 startTime = savingCircles.getCircle(circleId).effectiveCircleStartTime;
+
+    _depositFullRound(circleId);
+
+    // Day after window ends
+    vm.warp(startTime + interval + 1 days);
+    vm.prank(alice);
+    savingCircles.withdraw(circleId);
+  }
+
+  function test_LateClaimInNextRoundAllowsNextRoundDeposits() external {
+    uint256 interval = 7 days;
+    uint256 circleId = _createCircleWithInterval(interval);
+    uint256 startTime = savingCircles.getCircle(circleId).effectiveCircleStartTime;
+
+    _depositFullRound(circleId);
+
+    // Warp into round x+1 window (after round x ends)
+    vm.warp(startTime + interval + 1 days);
+    vm.prank(alice);
+    savingCircles.withdraw(circleId);
+
+    // After late claim, deposits for next round should still be allowed
+    _depositFullRound(circleId);
   }
 
   function test_RedeemInviteWhenSignatureIsValid() external {


### PR DESCRIPTION
This PR updates withdraw timing so claims are only allowed during the final 24 hours of each round’s deposit window (or later). It also updates unit and integration tests to warp into that last‑day window and to verify late claims still succeed. Note that the round does not advance until a withdrawal happens (`currentIndex` only increments on withdraw) so if a member claims late, the next round is delayed until that withdrawal is made.