### PR TITLE
Assess time based rounds and allow late claims

### DIFF
--- a/src/contracts/DelegatedSavingCircles.sol
+++ b/src/contracts/DelegatedSavingCircles.sol
@@ -150,11 +150,11 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
     // Check if delegated deposits are enabled for this member
     if (!delegatedDepositsEnabled[_member]) revert DelegatedDepositsNotEnabled();
 
+    if (SAVING_CIRCLES.isDecommissionable(_circleId)) revert ISavingCircles.NotActive();
+
     // Get circle information
     ISavingCircles.Circle memory _circle = SAVING_CIRCLES.getCircle(_circleId);
     address[] memory circleMembers = SAVING_CIRCLES.getCircleMembers(_circleId);
-
-    if (SAVING_CIRCLES.isDecommissionable(_circleId)) revert ISavingCircles.NotActive();
 
     // Check if member is part of the circle
     bool isMember = false;

--- a/src/contracts/DelegatedSavingCircles.sol
+++ b/src/contracts/DelegatedSavingCircles.sol
@@ -77,17 +77,17 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
         // Check if we're in a valid deposit window
         if (block.timestamp < _circle.effectiveCircleStartTime) continue;
 
-        uint256 depositWindowEnd =
-          _circle.effectiveCircleStartTime + (_circle.depositInterval * (_circle.currentIndex + 1));
-        if (block.timestamp >= depositWindowEnd) continue;
+        if (SAVING_CIRCLES.isDecommissionable(id)) continue;
 
-        if (block.timestamp >= _circle.circleEnd) continue;
+        uint256 currentRound = _currentRoundIndex(_circle);
+        if (currentRound >= circleMembers.length) continue;
 
+        (, uint256[] memory memberBalances) = SAVING_CIRCLES.getMemberBalances(id);
         for (uint256 j = 0; j < circleMembers.length; j++) {
           address member = circleMembers[j];
           if (!delegatedDepositsEnabled[member]) continue; // Skip if not opted in
 
-          uint256 currentBalance = SAVING_CIRCLES.balances(id, member);
+          uint256 currentBalance = memberBalances[j];
           if (currentBalance >= _circle.depositAmount) continue; // Already deposited
 
           uint256 requiredAmount = _circle.depositAmount - currentBalance;
@@ -114,17 +114,15 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
         // Check if we're in a valid deposit window
         if (block.timestamp < _circle.effectiveCircleStartTime) continue;
 
-        uint256 depositWindowEnd =
-          _circle.effectiveCircleStartTime + (_circle.depositInterval * (_circle.currentIndex + 1));
-        if (block.timestamp >= depositWindowEnd) continue;
+        uint256 currentRound = _currentRoundIndex(_circle);
+        if (currentRound >= circleMembers.length) continue;
 
-        if (block.timestamp >= _circle.circleEnd) continue;
-
+        (, uint256[] memory memberBalances) = SAVING_CIRCLES.getMemberBalances(id);
         for (uint256 j = 0; j < circleMembers.length; j++) {
           address member = circleMembers[j];
           if (!delegatedDepositsEnabled[member]) continue; // Skip if not opted in
 
-          uint256 currentBalance = SAVING_CIRCLES.balances(id, member);
+          uint256 currentBalance = memberBalances[j];
           if (currentBalance >= _circle.depositAmount) continue; // Already deposited
 
           uint256 requiredAmount = _circle.depositAmount - currentBalance;
@@ -156,6 +154,8 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
     ISavingCircles.Circle memory _circle = SAVING_CIRCLES.getCircle(_circleId);
     address[] memory circleMembers = SAVING_CIRCLES.getCircleMembers(_circleId);
 
+    if (SAVING_CIRCLES.isDecommissionable(_circleId)) revert ISavingCircles.NotActive();
+
     // Check if member is part of the circle
     bool isMember = false;
     for (uint256 i = 0; i < circleMembers.length; i++) {
@@ -167,7 +167,7 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
     if (!isMember) revert ISavingCircles.NotMember();
 
     // Calculate the remaining deposit amount needed
-    uint256 currentBalance = SAVING_CIRCLES.balances(_circleId, _member);
+    uint256 currentBalance = _memberBalance(_circleId, _member);
     if (currentBalance >= _circle.depositAmount) revert ISavingCircles.AlreadyDeposited();
     uint256 requiredAmount = _circle.depositAmount - currentBalance;
 
@@ -179,12 +179,8 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
     if (block.timestamp < _circle.effectiveCircleStartTime) {
       revert ISavingCircles.DepositBeforeCircleStart();
     }
-    // Check if current deposit window has closed (each window lasts depositInterval)
-    if (block.timestamp >= _circle.effectiveCircleStartTime + (_circle.depositInterval * (_circle.currentIndex + 1))) {
-      revert ISavingCircles.DepositWindowClosed();
-    }
     // Check if all deposit periods have passed
-    if (block.timestamp >= _circle.circleEnd) {
+    if (_currentRoundIndex(_circle) >= circleMembers.length) {
       revert ISavingCircles.CircleExpired();
     }
 
@@ -196,5 +192,26 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
 
     // Call depositFor on the main contract
     SAVING_CIRCLES.depositFor(_circleId, requiredAmount, _member);
+  }
+
+  function _currentRoundIndex(ISavingCircles.Circle memory _circle) internal view returns (uint256) {
+    if (
+      _circle.depositInterval == 0 || _circle.effectiveCircleStartTime == 0
+        || block.timestamp < _circle.effectiveCircleStartTime
+    ) {
+      return 0;
+    }
+
+    return (block.timestamp - _circle.effectiveCircleStartTime) / _circle.depositInterval;
+  }
+
+  function _memberBalance(uint256 _circleId, address _member) internal view returns (uint256) {
+    (address[] memory members, uint256[] memory balances) = SAVING_CIRCLES.getMemberBalances(_circleId);
+    for (uint256 i = 0; i < members.length; i++) {
+      if (members[i] == _member) {
+        return balances[i];
+      }
+    }
+    return 0;
   }
 }

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -36,6 +36,9 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => mapping(uint256 nonce => bool used)) public usedNonces;
   mapping(uint256 id => bool active) public isActive;
   mapping(uint256 id => address[] members) public circleMembers;
+  mapping(uint256 id => mapping(address member => bool claimed)) public hasClaimed;
+  mapping(uint256 id => mapping(address member => uint256 round)) private lastDepositRound;
+  mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
 
   /// @dev Requires circle is commissioned by checking if an owner is set
   modifier onlyCommissioned(uint256 _id) {
@@ -186,6 +189,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   /// @inheritdoc ISavingCircles
   function getCircle(uint256 _id) external view override onlyCommissioned(_id) returns (Circle memory _circle) {
     _circle = circles[_id];
+    _circle.currentIndex = _currentRoundIndex(_circle);
   }
 
   /// @inheritdoc ISavingCircles
@@ -194,6 +198,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
     for (uint256 i = 0; i < _ids.length; i++) {
       _circles[i] = circles[_ids[i]];
+      _circles[i].currentIndex = _currentRoundIndex(_circles[i]);
     }
   }
 
@@ -229,9 +234,15 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
     if (_isDecommissioned(_circle)) revert NotCommissioned();
 
+    uint256 currentRound = _currentRoundIndex(_circle);
     _balances = new uint256[](circleMembers[_id].length);
     for (uint256 i = 0; i < circleMembers[_id].length; i++) {
-      _balances[i] = balances[_id][circleMembers[_id][i]];
+      address member = circleMembers[_id][i];
+      if (lastDepositRound[_id][member] == currentRound) {
+        _balances[i] = balances[_id][member];
+      } else {
+        _balances[i] = 0;
+      }
     }
 
     return (circleMembers[_id], _balances);
@@ -254,7 +265,11 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   /// @inheritdoc ISavingCircles
   function isWithdrawable(uint256 _id) public view override returns (bool) {
     if (!isActive[_id]) return false;
-    return _withdrawable(_id);
+    Circle memory _circle = circles[_id];
+    uint256 currentRound = _currentRoundIndex(_circle);
+    if (currentRound >= circleMembers[_id].length) return false;
+    address member = circleMembers[_id][currentRound];
+    return _claimable(_id, member);
   }
 
   /// @inheritdoc ISavingCircles
@@ -262,7 +277,9 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     if (!isActive[_id]) return address(0);
     Circle memory _circle = circles[_id];
 
-    return circleMembers[_id][_circle.currentIndex];
+    uint256 currentRound = _currentRoundIndex(_circle);
+    if (currentRound >= circleMembers[_id].length) return address(0);
+    return circleMembers[_id][currentRound];
   }
 
   /**
@@ -273,20 +290,19 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   function _withdraw(uint256 _id, address _member) internal onlyMember(_id, msg.sender) {
     Circle storage _circle = circles[_id];
 
-    if (!_withdrawable(_id)) revert NotWithdrawable();
-    if (circleMembers[_id][_circle.currentIndex] != _member) revert NotWithdrawable();
-    if (_circle.currentIndex >= circleMembers[_id].length) revert NotWithdrawable();
+    if (!_claimable(_id, _member)) revert NotWithdrawable();
 
     uint256 _withdrawAmount = _circle.depositAmount * (circleMembers[_id].length);
 
-    for (uint256 i = 0; i < circleMembers[_id].length; i++) {
-      balances[_id][circleMembers[_id][i]] = 0;
-    }
+    hasClaimed[_id][_member] = true;
 
-    _circle.currentIndex = (_circle.currentIndex + 1) % circleMembers[_id].length;
     IERC20(_circle.token).safeTransfer(_member, _withdrawAmount);
 
     emit FundsWithdrawn(_id, _member, _withdrawAmount);
+
+    if (_allMembersClaimed(_id) && IERC20(_circle.token).balanceOf(address(this)) == 0) {
+      isActive[_id] = false;
+    }
   }
 
   /**
@@ -304,22 +320,29 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     if (block.timestamp < circles[_id].effectiveCircleStartTime) {
       revert DepositBeforeCircleStart();
     }
-    // Check if the entire circle has expired (all rounds completed)
-    if (block.timestamp >= _circle.circleEnd) {
+    uint256 currentRound = _currentRoundIndex(_circle);
+    if (currentRound >= circleMembers[_id].length) {
       revert CircleExpired();
     }
-    // Check if current deposit window is closed
-    if (
-      block.timestamp
-        >= circles[_id].effectiveCircleStartTime + (circles[_id].depositInterval * (circles[_id].currentIndex + 1))
-    ) {
-      revert DepositWindowClosed();
-    }
-    if (balances[_id][_member] + _value > circles[_id].depositAmount) {
-      revert ExceedsDepositAmount();
+
+    if (currentRound > 0) {
+      uint256 prev = currentRound - 1;
+      if (
+        block.timestamp > _roundEndTime(_circle, prev)
+          && !_allMembersDepositedForRound(_id, prev, _circle.depositAmount)
+      ) {
+        revert CircleStuck();
+      }
     }
 
-    balances[_id][_member] = balances[_id][_member] + _value;
+    uint256 depositedSoFar = roundDeposits[_id][currentRound][_member];
+    if (depositedSoFar + _value > _circle.depositAmount) revert ExceedsDepositAmount();
+
+    uint256 newTotal = depositedSoFar + _value;
+    roundDeposits[_id][currentRound][_member] = newTotal;
+
+    lastDepositRound[_id][_member] = currentRound;
+    balances[_id][_member] = newTotal;
 
     IERC20(_circle.token).safeTransferFrom(msg.sender, address(this), _value);
 
@@ -327,21 +350,19 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /**
-   * @dev Return if a specified circle is withdrawable
-   *      To be considered withdrawable, enough time must have passed since the deposit interval started
-   *      and all members must have made a deposit.
+   * @dev Return if a specified member can claim from a circle
+   *      Claim eligibility is determined by the time-based round index.
    */
-  function _withdrawable(uint256 _id) internal view onlyCommissioned(_id) returns (bool) {
+  function _claimable(uint256 _id, address _member) internal view onlyCommissioned(_id) returns (bool) {
     Circle memory _circle = circles[_id];
+    if (hasClaimed[_id][_member]) return false;
 
-    if (block.timestamp < _circle.effectiveCircleStartTime + (_circle.depositInterval * _circle.currentIndex)) {
-      return false;
-    }
-    address[] memory members = circleMembers[_id];
-    for (uint256 i = 0; i < members.length; i++) {
-      if (balances[_id][members[i]] < _circle.depositAmount) {
-        return false;
-      }
+    uint256 currentRound = _currentRoundIndex(_circle);
+    (uint256 memberIndex, bool found) = _memberIndex(_id, _member);
+    if (!found || currentRound < memberIndex) return false;
+
+    if (currentRound == memberIndex) {
+      return _allMembersDepositedForRound(_id, currentRound, _circle.depositAmount);
     }
 
     return true;
@@ -357,27 +378,72 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   /**
    * @dev Return if a specified circle is decommissionable
    *      To be considered decommissionable, the circle must have passed its deposit window
-   *      and all members must have made their deposits for the current round.
+   *      and some members must have incomplete deposits for the current round.
    */
   function _isDecommissionable(uint256 _id) internal view returns (bool) {
     Circle memory _circle = circles[_id];
-    bool decommissionable = true;
+    uint256 len = circleMembers[_id].length;
+    if (len == 0) return false;
 
-    if (block.timestamp <= _circle.effectiveCircleStartTime + (_circle.depositInterval * (_circle.currentIndex + 1))) {
-      decommissionable = false;
+    uint256 currentRound = _currentRoundIndex(_circle);
+
+    if (currentRound == 0) return false;
+
+    uint256 checkRound = currentRound - 1;
+
+    if (checkRound >= len) checkRound = len - 1;
+    if (block.timestamp <= _roundEndTime(_circle, checkRound)) return false;
+    return !_allMembersDepositedForRound(_id, checkRound, _circle.depositAmount);
+  }
+
+  function _roundEndTime(Circle memory _circle, uint256 round) internal pure returns (uint256) {
+    return _circle.effectiveCircleStartTime + (_circle.depositInterval * (round + 1));
+  }
+
+  function _currentRoundIndex(Circle memory _circle) internal view returns (uint256) {
+    if (
+      _circle.depositInterval == 0 || _circle.effectiveCircleStartTime == 0
+        || block.timestamp < _circle.effectiveCircleStartTime
+    ) {
+      return 0;
     }
 
-    bool hasIncompleteDeposits = false;
+    return (block.timestamp - _circle.effectiveCircleStartTime) / _circle.depositInterval;
+  }
+
+  function _allMembersDepositedForRound(
+    uint256 _id,
+    uint256 _round,
+    uint256 _depositAmount
+  ) internal view returns (bool) {
     address[] memory members = circleMembers[_id];
     for (uint256 i = 0; i < members.length; i++) {
-      if (balances[_id][members[i]] < _circle.depositAmount) {
-        hasIncompleteDeposits = true;
-        break;
+      address member = members[i];
+      if (roundDeposits[_id][_round][member] < _depositAmount) {
+        return false;
       }
     }
-    if (!hasIncompleteDeposits) decommissionable = false;
+    return true;
+  }
 
-    return decommissionable;
+  function _memberIndex(uint256 _id, address _member) internal view returns (uint256, bool) {
+    address[] memory members = circleMembers[_id];
+    for (uint256 i = 0; i < members.length; i++) {
+      if (members[i] == _member) {
+        return (i, true);
+      }
+    }
+    return (0, false);
+  }
+
+  function _allMembersClaimed(uint256 _id) internal view returns (bool) {
+    address[] memory members = circleMembers[_id];
+    for (uint256 i = 0; i < members.length; i++) {
+      if (!hasClaimed[_id][members[i]]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -342,7 +342,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
         block.timestamp >= _roundEndTime(_circle, prev)
           && !_allMembersDepositedForRound(_id, prev, _circle.depositAmount)
       ) {
-        revert CircleStuck();
+        revert CircleTimedOut();
       }
     }
 

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -39,7 +39,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => mapping(address member => bool claimed)) public hasClaimed;
   mapping(uint256 id => mapping(address member => uint256 round)) private _lastDepositRound;
   mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
-  mapping(uint256 id => mapping(address member => uint256 indexPlusOne)) private _memberIndexPlusOne;
+  // 1-based index so 0 can represent "not found"
+  mapping(uint256 id => mapping(address member => uint256 memberIndex)) private _memberIndex;
 
   /// @dev Requires circle is commissioned by checking if an owner is set
   modifier onlyCommissioned(uint256 _id) {
@@ -94,7 +95,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][owner] = true;
     memberCircles[owner].push(_id);
     circleMembers[_id].push(owner);
-    _memberIndexPlusOne[_id][owner] = circleMembers[_id].length;
+    _memberIndex[_id][owner] = circleMembers[_id].length;
 
     circles[_id] = _circle;
     emit CircleCreated(_id, _circle.token, _circle.depositAmount, _circle.depositInterval);
@@ -191,7 +192,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][msg.sender] = true;
     memberCircles[msg.sender].push(_id);
     circleMembers[_id].push(msg.sender);
-    _memberIndexPlusOne[_id][msg.sender] = circleMembers[_id].length;
+    _memberIndex[_id][msg.sender] = circleMembers[_id].length;
 
     emit InviteRedeemed(_id, msg.sender);
   }
@@ -369,7 +370,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     if (_isDecommissionable(_id)) return false;
 
     uint256 currentRound = _currentRoundIndex(_circle);
-    (uint256 memberIndex, bool found) = _memberIndex(_id, _member);
+    (uint256 memberIndex, bool found) = _getMemberIndex(_id, _member);
     if (!found || currentRound < memberIndex) return false;
 
     return _allMembersDepositedForRound(_id, memberIndex, _circle.depositAmount);
@@ -432,8 +433,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     return true;
   }
 
-  function _memberIndex(uint256 _id, address _member) internal view returns (uint256 index, bool found) {
-    uint256 indexPlusOne = _memberIndexPlusOne[_id][_member];
+  function _getMemberIndex(uint256 _id, address _member) internal view returns (uint256 index, bool found) {
+    uint256 indexPlusOne = _memberIndex[_id][_member];
     if (indexPlusOne == 0) return (0, false);
     return (indexPlusOne - 1, true);
   }

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -143,18 +143,26 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   function decommission(uint256 _id) external override nonReentrant onlyActive(_id) {
     if (!_isDecommissionable(_id)) revert NotDecommissionable();
 
+    Circle memory circle = circles[_id];
     address token = circles[_id].token;
     address[] memory members = circleMembers[_id];
+    uint256 len = members.length;
+
     isActive[_id] = false;
 
-    // Return deposits to members
-    for (uint256 i = 0; i < members.length; i++) {
-      address _member = members[i];
-      uint256 _balance = balances[_id][_member];
+    // Refund all deposits in rounds whose payout hasn't happened yet (recipient not claimed)
+    for (uint256 r = 0; r < len; r++) {
+      address recipient = members[r];
+      if (hasClaimed[_id][recipient]) continue; // round already paid out
 
-      if (_balance > 0) {
-        balances[_id][_member] = 0;
-        IERC20(token).safeTransfer(_member, _balance);
+      for (uint256 i = 0; i < len; i++) {
+        address member = members[i];
+        uint256 amount = roundDeposits[_id][r][member];
+        if (amount == 0) continue;
+
+        roundDeposits[_id][r][member] = 0;
+
+        IERC20(token).safeTransfer(member, amount);
       }
     }
 

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -336,7 +336,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     if (currentRound > 0) {
       uint256 prev = currentRound - 1;
       if (
-        block.timestamp > _roundEndTime(_circle, prev)
+        block.timestamp >= _roundEndTime(_circle, prev)
           && !_allMembersDepositedForRound(_id, prev, _circle.depositAmount)
       ) {
         revert CircleStuck();
@@ -397,7 +397,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     uint256 checkRound = currentRound - 1;
 
     if (checkRound >= len) checkRound = len - 1;
-    if (block.timestamp <= _roundEndTime(_circle, checkRound)) return false;
+    if (block.timestamp < _roundEndTime(_circle, checkRound)) return false;
     return !_allMembersDepositedForRound(_id, checkRound, _circle.depositAmount);
   }
 

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -152,7 +152,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
     isActive[_id] = false;
 
-    // Refund all deposits in rounds whose payout hasn't happened yet (recipient not claimed)
+    // Return all funds still held by the contract to the members who deposited them.
     for (uint256 r = 0; r < len; r++) {
       address recipient = members[r];
       if (hasClaimed[_id][recipient]) continue; // round already paid out

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -194,8 +194,9 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     // No max count validation, the owner issues a finite amount of invites
     isMember[_id][msg.sender] = true;
     memberCircles[msg.sender].push(_id);
-    circleMembers[_id].push(msg.sender);
-    _memberStates[_id][msg.sender].memberIndex = circleMembers[_id].length - 1;
+    address[] storage _circleMembers = circleMembers[_id];
+    _circleMembers.push(msg.sender);
+    _memberStates[_id][msg.sender].memberIndex = _circleMembers.length - 1;
 
     emit InviteRedeemed(_id, msg.sender);
   }

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -308,7 +308,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
     emit FundsWithdrawn(_id, _member, _withdrawAmount);
 
-    if (_allMembersClaimed(_id) && IERC20(_circle.token).balanceOf(address(this)) == 0) {
+    if (_allMembersClaimed(_id)) {
       isActive[_id] = false;
     }
   }

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -37,10 +37,10 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => bool active) public isActive;
   mapping(uint256 id => address[] members) public circleMembers;
   mapping(uint256 id => mapping(address member => bool claimed)) public hasClaimed;
-  mapping(uint256 id => mapping(address member => uint256 round)) private _lastDepositRound;
+  mapping(uint256 id => mapping(address member => uint256 round)) public lastDepositRound;
   mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
   // 1-based index so 0 can represent "not found"
-  mapping(uint256 id => mapping(address member => uint256 memberIndex)) private _memberIndex;
+  mapping(uint256 id => mapping(address member => uint256 memberIndex)) public memberIndex;
 
   /// @dev Requires circle is commissioned by checking if an owner is set
   modifier onlyCommissioned(uint256 _id) {
@@ -95,7 +95,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][owner] = true;
     memberCircles[owner].push(_id);
     circleMembers[_id].push(owner);
-    _memberIndex[_id][owner] = circleMembers[_id].length;
+    memberIndex[_id][owner] = circleMembers[_id].length;
 
     circles[_id] = _circle;
     emit CircleCreated(_id, _circle.token, _circle.depositAmount, _circle.depositInterval);
@@ -192,7 +192,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][msg.sender] = true;
     memberCircles[msg.sender].push(_id);
     circleMembers[_id].push(msg.sender);
-    _memberIndex[_id][msg.sender] = circleMembers[_id].length;
+    memberIndex[_id][msg.sender] = circleMembers[_id].length;
 
     emit InviteRedeemed(_id, msg.sender);
   }
@@ -249,7 +249,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     _balances = new uint256[](circleMembers[_id].length);
     for (uint256 i = 0; i < circleMembers[_id].length; i++) {
       address member = circleMembers[_id][i];
-      if (_lastDepositRound[_id][member] == currentRound) {
+      if (lastDepositRound[_id][member] == currentRound) {
         _balances[i] = balances[_id][member];
       } else {
         _balances[i] = 0;
@@ -352,7 +352,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     uint256 newTotal = depositedSoFar + _value;
     roundDeposits[_id][currentRound][_member] = newTotal;
 
-    _lastDepositRound[_id][_member] = currentRound;
+    lastDepositRound[_id][_member] = currentRound;
     balances[_id][_member] = newTotal;
 
     IERC20(_circle.token).safeTransferFrom(msg.sender, address(this), _value);
@@ -434,7 +434,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   function _getMemberIndex(uint256 _id, address _member) internal view returns (uint256 index, bool found) {
-    uint256 indexPlusOne = _memberIndex[_id][_member];
+    uint256 indexPlusOne = memberIndex[_id][_member];
     if (indexPlusOne == 0) return (0, false);
     return (indexPlusOne - 1, true);
   }

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -432,7 +432,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     return true;
   }
 
-  function _memberIndex(uint256 _id, address _member) internal view returns (uint256, bool found) {
+  function _memberIndex(uint256 _id, address _member) internal view returns (uint256 index, bool found) {
     uint256 indexPlusOne = _memberIndexPlusOne[_id][_member];
     if (indexPlusOne == 0) return (0, false);
     return (indexPlusOne - 1, true);

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -376,13 +376,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /**
-   * @dev Return if a specified circle is decommissioned by checking if an owner is set
-   */
-  function _isDecommissioned(Circle memory _circle) internal pure returns (bool) {
-    return _circle.owner == address(0);
-  }
-
-  /**
    * @dev Return if a specified circle is decommissionable
    *      To be considered decommissionable, the circle must have passed its deposit window
    *      and some members must have incomplete deposits for the current round.
@@ -403,9 +396,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     return !_allMembersDepositedForRound(_id, checkRound, _circle.depositAmount);
   }
 
-  function _roundEndTime(Circle memory _circle, uint256 round) internal pure returns (uint256) {
-    return _circle.effectiveCircleStartTime + (_circle.depositInterval * (round + 1));
-  }
   function _currentRoundIndex(Circle memory _circle) internal view returns (uint256) {
     if (
       _circle.depositInterval == 0 || _circle.effectiveCircleStartTime == 0
@@ -445,6 +435,17 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
       }
     }
     return true;
+  }
+
+  /**
+   * @dev Return if a specified circle is decommissioned by checking if an owner is set
+   */
+  function _isDecommissioned(Circle memory _circle) internal pure returns (bool) {
+    return _circle.owner == address(0);
+  }
+
+  function _roundEndTime(Circle memory _circle, uint256 round) internal pure returns (uint256) {
+    return _circle.effectiveCircleStartTime + (_circle.depositInterval * (round + 1));
   }
 
   /**

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -37,9 +37,9 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => bool active) public isActive;
   mapping(uint256 id => address[] members) public circleMembers;
   mapping(uint256 id => mapping(address member => bool claimed)) public hasClaimed;
-  mapping(uint256 id => mapping(address member => uint256 round)) private lastDepositRound;
+  mapping(uint256 id => mapping(address member => uint256 round)) private _lastDepositRound;
   mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
-  mapping(uint256 id => mapping(address member => uint256 indexPlusOne)) private memberIndexPlusOne;
+  mapping(uint256 id => mapping(address member => uint256 indexPlusOne)) private _memberIndexPlusOne;
 
   /// @dev Requires circle is commissioned by checking if an owner is set
   modifier onlyCommissioned(uint256 _id) {
@@ -94,7 +94,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][owner] = true;
     memberCircles[owner].push(_id);
     circleMembers[_id].push(owner);
-    memberIndexPlusOne[_id][owner] = circleMembers[_id].length;
+    _memberIndexPlusOne[_id][owner] = circleMembers[_id].length;
 
     circles[_id] = _circle;
     emit CircleCreated(_id, _circle.token, _circle.depositAmount, _circle.depositInterval);
@@ -145,7 +145,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   function decommission(uint256 _id) external override nonReentrant onlyActive(_id) {
     if (!_isDecommissionable(_id)) revert NotDecommissionable();
 
-    Circle memory circle = circles[_id];
     address token = circles[_id].token;
     address[] memory members = circleMembers[_id];
     uint256 len = members.length;
@@ -192,7 +191,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][msg.sender] = true;
     memberCircles[msg.sender].push(_id);
     circleMembers[_id].push(msg.sender);
-    memberIndexPlusOne[_id][msg.sender] = circleMembers[_id].length;
+    _memberIndexPlusOne[_id][msg.sender] = circleMembers[_id].length;
 
     emit InviteRedeemed(_id, msg.sender);
   }
@@ -249,7 +248,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     _balances = new uint256[](circleMembers[_id].length);
     for (uint256 i = 0; i < circleMembers[_id].length; i++) {
       address member = circleMembers[_id][i];
-      if (lastDepositRound[_id][member] == currentRound) {
+      if (_lastDepositRound[_id][member] == currentRound) {
         _balances[i] = balances[_id][member];
       } else {
         _balances[i] = 0;
@@ -352,7 +351,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     uint256 newTotal = depositedSoFar + _value;
     roundDeposits[_id][currentRound][_member] = newTotal;
 
-    lastDepositRound[_id][_member] = currentRound;
+    _lastDepositRound[_id][_member] = currentRound;
     balances[_id][_member] = newTotal;
 
     IERC20(_circle.token).safeTransferFrom(msg.sender, address(this), _value);
@@ -407,7 +406,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   function _roundEndTime(Circle memory _circle, uint256 round) internal pure returns (uint256) {
     return _circle.effectiveCircleStartTime + (_circle.depositInterval * (round + 1));
   }
-
   function _currentRoundIndex(Circle memory _circle) internal view returns (uint256) {
     if (
       _circle.depositInterval == 0 || _circle.effectiveCircleStartTime == 0
@@ -435,7 +433,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   function _memberIndex(uint256 _id, address _member) internal view returns (uint256, bool) {
-    uint256 indexPlusOne = memberIndexPlusOne[_id][_member];
+    uint256 indexPlusOne = _memberIndexPlusOne[_id][_member];
     if (indexPlusOne == 0) return (0, false);
     return (indexPlusOne - 1, true);
   }

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -148,16 +148,16 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
     address token = circles[_id].token;
     address[] memory members = circleMembers[_id];
-    uint256 len = members.length;
+    uint256 membersLength = members.length;
 
     isActive[_id] = false;
 
     // Return all funds still held by the contract to the members who deposited them.
-    for (uint256 r = 0; r < len; r++) {
+    for (uint256 r = 0; r < membersLength; r++) {
       address recipient = members[r];
       if (hasClaimed[_id][recipient]) continue; // round already paid out
 
-      for (uint256 i = 0; i < len; i++) {
+      for (uint256 i = 0; i < membersLength; i++) {
         address member = members[i];
         uint256 amount = roundDeposits[_id][r][member];
         if (amount == 0) continue;

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -432,7 +432,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     return true;
   }
 
-  function _memberIndex(uint256 _id, address _member) internal view returns (uint256, bool) {
+  function _memberIndex(uint256 _id, address _member) internal view returns (uint256, bool found) {
     uint256 indexPlusOne = _memberIndexPlusOne[_id][_member];
     if (indexPlusOne == 0) return (0, false);
     return (indexPlusOne - 1, true);

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -364,16 +364,13 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   function _claimable(uint256 _id, address _member) internal view onlyCommissioned(_id) returns (bool) {
     Circle memory _circle = circles[_id];
     if (hasClaimed[_id][_member]) return false;
+    if (_isDecommissionable(_id)) return false;
 
     uint256 currentRound = _currentRoundIndex(_circle);
     (uint256 memberIndex, bool found) = _memberIndex(_id, _member);
     if (!found || currentRound < memberIndex) return false;
 
-    if (currentRound == memberIndex) {
-      return _allMembersDepositedForRound(_id, currentRound, _circle.depositAmount);
-    }
-
-    return true;
+    return _allMembersDepositedForRound(_id, memberIndex, _circle.depositAmount);
   }
 
   /**

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -94,7 +94,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][owner] = true;
     memberCircles[owner].push(_id);
     circleMembers[_id].push(owner);
-    memberIndex[_id][owner] = circleMembers[_id].length - 1;
+    memberIndex[_id][owner] = 0;
 
     circles[_id] = _circle;
     emit CircleCreated(_id, _circle.token, _circle.depositAmount, _circle.depositInterval);

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -39,7 +39,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => mapping(address member => bool claimed)) public hasClaimed;
   mapping(uint256 id => mapping(address member => uint256 round)) public lastDepositRound;
   mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
-  // 1-based index so 0 can represent "not found"
   mapping(uint256 id => mapping(address member => uint256 memberIndex)) public memberIndex;
 
   /// @dev Requires circle is commissioned by checking if an owner is set
@@ -95,7 +94,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][owner] = true;
     memberCircles[owner].push(_id);
     circleMembers[_id].push(owner);
-    memberIndex[_id][owner] = circleMembers[_id].length;
+    memberIndex[_id][owner] = circleMembers[_id].length - 1;
 
     circles[_id] = _circle;
     emit CircleCreated(_id, _circle.token, _circle.depositAmount, _circle.depositInterval);
@@ -192,7 +191,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][msg.sender] = true;
     memberCircles[msg.sender].push(_id);
     circleMembers[_id].push(msg.sender);
-    memberIndex[_id][msg.sender] = circleMembers[_id].length;
+    memberIndex[_id][msg.sender] = circleMembers[_id].length - 1;
 
     emit InviteRedeemed(_id, msg.sender);
   }
@@ -434,9 +433,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   function _getMemberIndex(uint256 _id, address _member) internal view returns (uint256 index, bool found) {
-    uint256 indexPlusOne = memberIndex[_id][_member];
-    if (indexPlusOne == 0) return (0, false);
-    return (indexPlusOne - 1, true);
+    if (!isMember[_id][_member]) return (0, false);
+    return (memberIndex[_id][_member], true);
   }
 
   function _allMembersClaimed(uint256 _id) internal view returns (bool) {

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -393,8 +393,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
   /**
    * @dev Return if a specified circle is decommissionable
-   *      To be considered decommissionable, the circle must have passed its deposit window
-   *      and some members must have incomplete deposits for the current round.
+   *      To be considered decommissionable, the previous round's deposit window must have ended
+   *      and that round must have incomplete deposits.
    */
   function _isDecommissionable(uint256 _id) internal view returns (bool) {
     Circle memory _circle = circles[_id];

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -299,7 +299,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /// @inheritdoc ISavingCircles
-  function withdrawableBy(uint256 _id) public view override onlyCommissioned(_id) returns (address) {
+  function currentRoundWithdrawer(uint256 _id) public view override onlyCommissioned(_id) returns (address) {
     if (!isActive[_id]) return address(0);
     Circle memory _circle = circles[_id];
 

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -39,6 +39,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => mapping(address member => bool claimed)) public hasClaimed;
   mapping(uint256 id => mapping(address member => uint256 round)) private lastDepositRound;
   mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
+  mapping(uint256 id => mapping(address member => uint256 indexPlusOne)) private memberIndexPlusOne;
 
   /// @dev Requires circle is commissioned by checking if an owner is set
   modifier onlyCommissioned(uint256 _id) {
@@ -93,6 +94,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][owner] = true;
     memberCircles[owner].push(_id);
     circleMembers[_id].push(owner);
+    memberIndexPlusOne[_id][owner] = circleMembers[_id].length;
 
     circles[_id] = _circle;
     emit CircleCreated(_id, _circle.token, _circle.depositAmount, _circle.depositInterval);
@@ -190,6 +192,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][msg.sender] = true;
     memberCircles[msg.sender].push(_id);
     circleMembers[_id].push(msg.sender);
+    memberIndexPlusOne[_id][msg.sender] = circleMembers[_id].length;
 
     emit InviteRedeemed(_id, msg.sender);
   }
@@ -432,13 +435,9 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   function _memberIndex(uint256 _id, address _member) internal view returns (uint256, bool) {
-    address[] memory members = circleMembers[_id];
-    for (uint256 i = 0; i < members.length; i++) {
-      if (members[i] == _member) {
-        return (i, true);
-      }
-    }
-    return (0, false);
+    uint256 indexPlusOne = memberIndexPlusOne[_id][_member];
+    if (indexPlusOne == 0) return (0, false);
+    return (indexPlusOne - 1, true);
   }
 
   function _allMembersClaimed(uint256 _id) internal view returns (bool) {

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -22,6 +22,12 @@ using SafeERC20 for IERC20;
  * @author valeriooconte
  */
 contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpgradeable, EIP712Upgradeable {
+  struct MemberState {
+    bool hasClaimed;
+    uint256 lastDepositRound;
+    uint256 memberIndex;
+  }
+
   uint256 public constant MINIMUM_MEMBERS = 2;
   string private constant _EIP712_NAME = 'StacksInvite';
   string private constant _EIP712_VERSION = '1';
@@ -36,10 +42,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => mapping(uint256 nonce => bool used)) public usedNonces;
   mapping(uint256 id => bool active) public isActive;
   mapping(uint256 id => address[] members) public circleMembers;
-  mapping(uint256 id => mapping(address member => bool claimed)) public hasClaimed;
-  mapping(uint256 id => mapping(address member => uint256 round)) public lastDepositRound;
+  mapping(uint256 id => mapping(address member => MemberState state)) internal _memberStates;
   mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
-  mapping(uint256 id => mapping(address member => uint256 memberIndex)) public memberIndex;
 
   /// @dev Requires circle is commissioned by checking if an owner is set
   modifier onlyCommissioned(uint256 _id) {
@@ -94,7 +98,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][owner] = true;
     memberCircles[owner].push(_id);
     circleMembers[_id].push(owner);
-    memberIndex[_id][owner] = 0;
+    _memberStates[_id][owner].memberIndex = 0;
 
     circles[_id] = _circle;
     emit CircleCreated(_id, _circle.token, _circle.depositAmount, _circle.depositInterval);
@@ -154,7 +158,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     // Return all funds still held by the contract to the members who deposited them.
     for (uint256 r = 0; r < membersLength; r++) {
       address recipient = members[r];
-      if (hasClaimed[_id][recipient]) continue; // round already paid out
+      if (_memberStates[_id][recipient].hasClaimed) continue; // round already paid out
 
       for (uint256 i = 0; i < membersLength; i++) {
         address member = members[i];
@@ -191,7 +195,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     isMember[_id][msg.sender] = true;
     memberCircles[msg.sender].push(_id);
     circleMembers[_id].push(msg.sender);
-    memberIndex[_id][msg.sender] = circleMembers[_id].length - 1;
+    _memberStates[_id][msg.sender].memberIndex = circleMembers[_id].length - 1;
 
     emit InviteRedeemed(_id, msg.sender);
   }
@@ -248,7 +252,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     _balances = new uint256[](circleMembers[_id].length);
     for (uint256 i = 0; i < circleMembers[_id].length; i++) {
       address member = circleMembers[_id][i];
-      if (lastDepositRound[_id][member] == currentRound) {
+      if (_memberStates[_id][member].lastDepositRound == currentRound) {
         _balances[i] = balances[_id][member];
       } else {
         _balances[i] = 0;
@@ -265,6 +269,18 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
   function isDecommissionable(uint256 _id) external view override returns (bool) {
     return _isDecommissionable(_id);
+  }
+
+  function hasClaimed(uint256 _id, address _member) external view returns (bool claimed) {
+    return _memberStates[_id][_member].hasClaimed;
+  }
+
+  function lastDepositRound(uint256 _id, address _member) external view returns (uint256 round) {
+    return _memberStates[_id][_member].lastDepositRound;
+  }
+
+  function memberIndex(uint256 _id, address _member) external view returns (uint256 index) {
+    return _memberStates[_id][_member].memberIndex;
   }
 
   /// @inheritdoc ISavingCircles
@@ -304,7 +320,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
     uint256 _withdrawAmount = _circle.depositAmount * (circleMembers[_id].length);
 
-    hasClaimed[_id][_member] = true;
+    _memberStates[_id][_member].hasClaimed = true;
 
     IERC20(_circle.token).safeTransfer(_member, _withdrawAmount);
 
@@ -351,7 +367,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     uint256 newTotal = depositedSoFar + _value;
     roundDeposits[_id][currentRound][_member] = newTotal;
 
-    lastDepositRound[_id][_member] = currentRound;
+    _memberStates[_id][_member].lastDepositRound = currentRound;
     balances[_id][_member] = newTotal;
 
     IERC20(_circle.token).safeTransferFrom(msg.sender, address(this), _value);
@@ -365,14 +381,14 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
    */
   function _claimable(uint256 _id, address _member) internal view onlyCommissioned(_id) returns (bool) {
     Circle memory _circle = circles[_id];
-    if (hasClaimed[_id][_member]) return false;
+    if (_memberStates[_id][_member].hasClaimed) return false;
     if (_isDecommissionable(_id)) return false;
 
     uint256 currentRound = _currentRoundIndex(_circle);
-    (uint256 memberIndex, bool found) = _getMemberIndex(_id, _member);
-    if (!found || currentRound < memberIndex) return false;
+    (uint256 memberIdx, bool found) = _getMemberIndex(_id, _member);
+    if (!found || currentRound < memberIdx) return false;
 
-    return _allMembersDepositedForRound(_id, memberIndex, _circle.depositAmount);
+    return _allMembersDepositedForRound(_id, memberIdx, _circle.depositAmount);
   }
 
   /**
@@ -424,13 +440,13 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
   function _getMemberIndex(uint256 _id, address _member) internal view returns (uint256 index, bool found) {
     if (!isMember[_id][_member]) return (0, false);
-    return (memberIndex[_id][_member], true);
+    return (_memberStates[_id][_member].memberIndex, true);
   }
 
   function _allMembersClaimed(uint256 _id) internal view returns (bool) {
     address[] memory members = circleMembers[_id];
     for (uint256 i = 0; i < members.length; i++) {
-      if (!hasClaimed[_id][members[i]]) {
+      if (!_memberStates[_id][members[i]].hasClaimed) {
         return false;
       }
     }

--- a/src/contracts/SavingCirclesViewer.sol
+++ b/src/contracts/SavingCirclesViewer.sol
@@ -302,7 +302,7 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
   ) internal view {
     circleData.isOwner = (circle.owner == _user);
 
-    address currentWithdrawer = SAVING_CIRCLES.withdrawableBy(_circleId);
+    address currentWithdrawer = SAVING_CIRCLES.currentRoundWithdrawer(_circleId);
     circleData.currentWithdrawer = currentWithdrawer;
     circleData.isCurrentWithdrawer = (currentWithdrawer == _user);
     circleData.canWithdraw = circleData.isCurrentWithdrawer && SAVING_CIRCLES.isWithdrawable(_circleId);

--- a/src/contracts/SavingCirclesViewer.sol
+++ b/src/contracts/SavingCirclesViewer.sol
@@ -108,7 +108,7 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
     uint256[] memory _ids = SAVING_CIRCLES.getMemberCircles(_member);
 
     for (uint256 i = 0; i < _ids.length; i++) {
-      _totalBalance += SAVING_CIRCLES.balances(_ids[i], _member);
+      _totalBalance += _memberBalance(_ids[i], _member);
     }
 
     return _totalBalance;
@@ -331,6 +331,16 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
       }
     }
     circleData.remainingDepositsNeeded = memberBalances.length - membersWithFullDeposits;
+  }
+
+  function _memberBalance(uint256 _circleId, address _member) internal view returns (uint256) {
+    (address[] memory members, uint256[] memory balances) = SAVING_CIRCLES.getMemberBalances(_circleId);
+    for (uint256 i = 0; i < members.length; i++) {
+      if (members[i] == _member) {
+        return balances[i];
+      }
+    }
+    return 0;
   }
 
   function _isInArray(uint256 value, uint256[] memory array) internal pure returns (bool) {

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -350,9 +350,9 @@ interface ISavingCircles {
   /**
    * @notice Get the address of the withdrawable by
    * @param id The ID of the circle
-   * @return withdrawableBy The address of the withdrawable by
+   * @return currentRoundWithdrawer The address of the current round withdrawer
    */
-  function withdrawableBy(uint256 id) external view returns (address withdrawableBy);
+  function currentRoundWithdrawer(uint256 id) external view returns (address currentRoundWithdrawer);
 
   /**
    * @notice Get the next ID that will be assigned to a new circle

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -204,7 +204,7 @@ interface ISavingCircles {
    */
   error NotActive();
   /**
-   * @notice Thrown when a deposit is missed
+   * @notice Thrown when a previous round ended with incomplete deposits, blocking deposits and withdrawals until decommission
    */
   error CircleTimedOut();
 

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -206,7 +206,7 @@ interface ISavingCircles {
   /**
    * @notice Thrown when a deposit is missed
    */
-  error CircleStuck();
+  error CircleTimedOut();
 
   /**
    * @notice Initialize the contract

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -203,6 +203,10 @@ interface ISavingCircles {
    * @notice Thrown when the circle is not active
    */
   error NotActive();
+  /**
+   * @notice Thrown when a deposit is missed
+   */
+  error CircleStuck();
 
   /**
    * @notice Initialize the contract

--- a/test/fuzz/SavingCirclesFuzz.t.sol
+++ b/test/fuzz/SavingCirclesFuzz.t.sol
@@ -209,16 +209,16 @@ contract SavingCirclesFuzzTest is SavingCirclesTestBase {
 
     ISavingCircles.Circle memory circle = _defaultCircle(alice, _depositAmount, _depositInterval, address(token));
 
-    if (_depositAmount == 0) {
+    if (_depositInterval == 0) {
       vm.prank(alice);
-      vm.expectRevert(ISavingCircles.InvalidDepositAmount.selector);
+      vm.expectRevert(ISavingCircles.InvalidDepositInterval.selector);
       savingCircles.create(circle);
       return;
     }
 
-    if (_depositInterval == 0) {
+    if (_depositAmount == 0) {
       vm.prank(alice);
-      vm.expectRevert(ISavingCircles.InvalidDepositInterval.selector);
+      vm.expectRevert(ISavingCircles.InvalidDepositAmount.selector);
       savingCircles.create(circle);
       return;
     }

--- a/test/fuzz/SavingCirclesFuzz.t.sol
+++ b/test/fuzz/SavingCirclesFuzz.t.sol
@@ -184,7 +184,7 @@ contract SavingCirclesFuzzTest is SavingCirclesTestBase {
       vm.stopPrank();
     }
 
-    vm.warp(block.timestamp + 2 days);
+    vm.warp(block.timestamp + 2 days + 1 hours);
 
     vm.prank(alice);
     savingCircles.decommission(circleId);
@@ -240,20 +240,33 @@ contract SavingCirclesFuzzTest is SavingCirclesTestBase {
     ISavingCircles.Circle memory circle = _defaultCircle(alice, depositAmount, _depositInterval, address(token));
 
     uint256 circleId = _createCircleWithMembers(savingCircles, circle, members, _alicePrivateKey);
+    uint256 startTime = savingCircles.getCircle(circleId).effectiveCircleStartTime;
+
+    // If we are past round 0, complete round 0 first so the circle isn't stuck
+    if (_timeOffset >= _depositInterval) {
+      token.mint(alice, depositAmount);
+      vm.startPrank(alice);
+      token.approve(address(savingCircles), depositAmount);
+      vm.warp(startTime);
+      savingCircles.deposit(circleId, depositAmount);
+      vm.stopPrank();
+
+      token.mint(bob, depositAmount);
+      vm.startPrank(bob);
+      token.approve(address(savingCircles), depositAmount);
+      savingCircles.deposit(circleId, depositAmount);
+      vm.stopPrank();
+    }
 
     token.mint(alice, depositAmount);
     vm.startPrank(alice);
     token.approve(address(savingCircles), depositAmount);
 
-    uint256 startTime = savingCircles.getCircle(circleId).effectiveCircleStartTime;
     vm.warp(startTime + _timeOffset);
 
     uint256 maxDuration = _depositInterval * members.length;
     if (_timeOffset >= maxDuration) {
       vm.expectRevert(ISavingCircles.CircleExpired.selector);
-      savingCircles.deposit(circleId, depositAmount);
-    } else if (_timeOffset >= _depositInterval) {
-      vm.expectRevert(ISavingCircles.DepositWindowClosed.selector);
       savingCircles.deposit(circleId, depositAmount);
     } else {
       savingCircles.deposit(circleId, depositAmount);

--- a/test/fuzz/SavingCirclesMultiRound.t.sol
+++ b/test/fuzz/SavingCirclesMultiRound.t.sol
@@ -443,7 +443,7 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
       token.approve(address(savingCircles), 1000);
 
       // Should revert as deposit window is closed and circle is stuck
-      vm.expectRevert(ISavingCircles.CircleStuck.selector);
+      vm.expectRevert(ISavingCircles.CircleTimedOut.selector);
       savingCircles.deposit(circleId, 1000);
       vm.stopPrank();
     }

--- a/test/fuzz/SavingCirclesMultiRound.t.sol
+++ b/test/fuzz/SavingCirclesMultiRound.t.sol
@@ -86,6 +86,7 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
 
     // Complete the full circle (each member gets one withdrawal)
     for (uint256 round = 0; round < _memberCount; round++) {
+      vm.warp(startTime + (_depositInterval * round));
       // All members deposit for this round
       for (uint256 i = 0; i < _memberCount; i++) {
         token.mint(members[i], _depositAmount);
@@ -95,17 +96,12 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
         vm.stopPrank();
       }
 
-      // Wait for current deposit interval to complete (withdrawal time)
-      vm.warp(startTime + (_depositInterval * (round + 1)));
-
       // Verify withdrawability
       assertTrue(savingCircles.isWithdrawable(circleId));
 
       // Get current recipient before withdrawal
-      ISavingCircles.Circle memory currentCircle = savingCircles.getCircle(circleId);
-      address[] memory storedMembers = savingCircles.getCircleMembers(circleId);
-      address expectedRecipient = storedMembers[currentCircle.currentIndex];
-      uint256 recipientIndex = currentCircle.currentIndex;
+      address expectedRecipient = members[round];
+      uint256 recipientIndex = round;
 
       // Withdraw for current round
       uint256 balanceBefore = token.balanceOf(expectedRecipient);
@@ -176,8 +172,7 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
 
     // Wait and withdraw from all circles
     for (uint256 c = 0; c < _numCircles; c++) {
-      vm.warp(startTimes[c] + _depositInterval);
-
+      vm.warp(startTimes[c] + _depositInterval - 1);
       assertTrue(savingCircles.isWithdrawable(circleIds[c]));
 
       address withdrawer = allMembers[c][0];
@@ -218,6 +213,7 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
 
     // Complete some rounds
     for (uint256 round = 0; round < _roundsBeforeDecommission; round++) {
+      vm.warp(startTime + (_depositInterval * round));
       for (uint256 i = 0; i < _memberCount; i++) {
         token.mint(members[i], _depositAmount);
         vm.startPrank(members[i]);
@@ -226,11 +222,7 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
         vm.stopPrank();
       }
 
-      vm.warp(startTime + (_depositInterval * (round + 1)));
-
-      ISavingCircles.Circle memory currentCircle = savingCircles.getCircle(circleId);
-      address[] memory storedMembers = savingCircles.getCircleMembers(circleId);
-      address recipient = storedMembers[currentCircle.currentIndex];
+      address recipient = members[round];
       vm.prank(recipient);
       savingCircles.withdraw(circleId);
     }
@@ -318,18 +310,19 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
           vm.stopPrank();
         }
 
-        vm.warp(liveCircle.effectiveCircleStartTime + (liveCircle.depositInterval * (round + 1)));
+        vm.warp(liveCircle.effectiveCircleStartTime + (liveCircle.depositInterval * round) + 1);
 
-        ISavingCircles.Circle memory currentCircle = savingCircles.getCircle(circleId);
-        address[] memory storedMembers = savingCircles.getCircleMembers(circleId);
-        address recipient = storedMembers[currentCircle.currentIndex];
+        address recipient = members[round];
         uint256 balanceBefore = token.balanceOf(recipient);
 
+        assertTrue(savingCircles.isWithdrawable(circleId));
         vm.prank(recipient);
         savingCircles.withdraw(circleId);
 
-        uint256 balanceAfter = token.balanceOf(recipient);
-        payouts[currentCircle.currentIndex] = balanceAfter - balanceBefore;
+        uint256 expectedPayout = circleDepositAmount * _memberCount;
+        assertEq(token.balanceOf(recipient), balanceBefore + expectedPayout);
+
+        payouts[round] = expectedPayout;
       }
 
       // Verify everyone received their payout in this circle
@@ -365,15 +358,11 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
         vm.stopPrank();
       }
 
-      // Wait for withdrawal window
-      vm.warp(startTime + (1 days * (round + 1)));
-
-      ISavingCircles.Circle memory currentCircle = savingCircles.getCircle(circleId);
-      address[] memory storedMembers = savingCircles.getCircleMembers(circleId);
-      address withdrawer = storedMembers[currentCircle.currentIndex];
+      address withdrawer = members[round];
 
       vm.prank(withdrawer);
       savingCircles.withdraw(circleId);
+      vm.warp(startTime + (1 days * (round + 1)));
     }
 
     // Verify circle completed successfully
@@ -453,8 +442,8 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
       vm.startPrank(members[i]);
       token.approve(address(savingCircles), 1000);
 
-      // Should revert as deposit window is closed
-      vm.expectRevert(ISavingCircles.DepositWindowClosed.selector);
+      // Should revert as deposit window is closed and circle is stuck
+      vm.expectRevert(ISavingCircles.CircleStuck.selector);
       savingCircles.deposit(circleId, 1000);
       vm.stopPrank();
     }
@@ -490,6 +479,7 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
     address[] memory withdrawalOrder = new address[](_rounds);
 
     for (uint256 round = 0; round < _rounds; round++) {
+      vm.warp(startTime + (depositInterval * round) + 1);
       // All members deposit
       for (uint256 i = 0; i < _memberCount; i++) {
         token.mint(members[i], 1000);
@@ -499,15 +489,12 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
         vm.stopPrank();
       }
 
-      // Move to withdrawal time
-      vm.warp(startTime + (depositInterval * (round + 1)));
-
       // Check who should withdraw
       ISavingCircles.Circle memory currentCircle = savingCircles.getCircle(circleId);
       address expectedWithdrawer = savingCircles.withdrawableBy(circleId);
 
       // Verify it's the correct member based on currentIndex
-      assertEq(expectedWithdrawer, members[currentCircle.currentIndex], 'Wrong withdrawal order');
+      assertEq(expectedWithdrawer, members[round], 'Wrong withdrawal order');
 
       // Perform withdrawal
       vm.prank(expectedWithdrawer);

--- a/test/fuzz/SavingCirclesMultiRound.t.sol
+++ b/test/fuzz/SavingCirclesMultiRound.t.sol
@@ -490,7 +490,6 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
       }
 
       // Check who should withdraw
-      ISavingCircles.Circle memory currentCircle = savingCircles.getCircle(circleId);
       address expectedWithdrawer = savingCircles.withdrawableBy(circleId);
 
       // Verify it's the correct member based on currentIndex

--- a/test/fuzz/SavingCirclesMultiRound.t.sol
+++ b/test/fuzz/SavingCirclesMultiRound.t.sol
@@ -490,7 +490,7 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
       }
 
       // Check who should withdraw
-      address expectedWithdrawer = savingCircles.withdrawableBy(circleId);
+      address expectedWithdrawer = savingCircles.currentRoundWithdrawer(circleId);
 
       // Verify it's the correct member based on currentIndex
       assertEq(expectedWithdrawer, members[round], 'Wrong withdrawal order');

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -179,7 +179,7 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     vm.warp(block.timestamp + DEPOSIT_INTERVAL + 1);
 
     vm.prank(alice);
-    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.DepositWindowClosed.selector));
+    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.CircleStuck.selector));
     savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
   }
 

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -212,11 +212,23 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     // At circle start, current round is 0 (alice's round). Bob's round is later.
     ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
     assertEq(circle.currentIndex, 0);
-    assertEq(savingCircles.memberIndex(baseCircleId, bob), 2); // 1-based index
+    assertEq(savingCircles.memberIndex(baseCircleId, bob), 1); // 0-based index
 
     vm.prank(bob);
     vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotWithdrawable.selector));
     savingCircles.withdraw(baseCircleId);
+  }
+
+  function test_MemberIndexIsZeroBasedAndOwnerFirst() external view {
+    address[] memory storedMembers = savingCircles.getCircleMembers(baseCircleId);
+
+    assertEq(storedMembers[0], alice);
+    assertEq(storedMembers[1], bob);
+    assertEq(storedMembers[2], carol);
+
+    assertEq(savingCircles.memberIndex(baseCircleId, alice), 0);
+    assertEq(savingCircles.memberIndex(baseCircleId, bob), 1);
+    assertEq(savingCircles.memberIndex(baseCircleId, carol), 2);
   }
 
   function test_WithdrawPastRoundClaimsSucceedSameBlock() external {

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -179,7 +179,7 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     vm.warp(block.timestamp + DEPOSIT_INTERVAL + 1);
 
     vm.prank(alice);
-    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.CircleStuck.selector));
+    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.CircleTimedOut.selector));
     savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
   }
 

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -254,7 +254,7 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     uint256 withdrawAmount = DEPOSIT_AMOUNT * members.length;
 
     // Current-round withdrawable member is carol, but prior-round members should still be claimable.
-    assertEq(savingCircles.withdrawableBy(baseCircleId), carol);
+    assertEq(savingCircles.currentRoundWithdrawer(baseCircleId), carol);
 
     vm.prank(alice);
     savingCircles.withdraw(baseCircleId);
@@ -282,7 +282,7 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
 
     // Move to round N = 1 (bob's round). Carol is a future-round member (round 2).
     vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
-    assertEq(savingCircles.withdrawableBy(baseCircleId), bob);
+    assertEq(savingCircles.currentRoundWithdrawer(baseCircleId), bob);
 
     vm.prank(carol);
     vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotWithdrawable.selector));

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -208,6 +208,168 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     savingCircles.withdraw(baseCircleId);
   }
 
+  function test_WithdrawFutureRoundMemberReverts() external {
+    // At circle start, current round is 0 (alice's round). Bob's round is later.
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    assertEq(circle.currentIndex, 0);
+    assertEq(savingCircles.memberIndex(baseCircleId, bob), 2); // 1-based index
+
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotWithdrawable.selector));
+    savingCircles.withdraw(baseCircleId);
+  }
+
+  function test_WithdrawPastRoundClaimsSucceedSameBlock() external {
+    // Use N = 2 on a 3-member circle: prior-round members are alice (round 0) and bob (round 1).
+    // We must complete deposits for rounds 0 and 1 so both become claimable.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT * 2);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT * 2);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 0
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
+    for (uint256 i = 0; i < members.length; i++) {
+      vm.startPrank(members[i]);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 1
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 2)); // now at round N = 2
+    uint256 claimTimestamp = block.timestamp;
+    uint256 withdrawAmount = DEPOSIT_AMOUNT * members.length;
+
+    // Current-round withdrawable member is carol, but prior-round members should still be claimable.
+    assertEq(savingCircles.withdrawableBy(baseCircleId), carol);
+
+    vm.prank(alice);
+    savingCircles.withdraw(baseCircleId);
+    vm.prank(bob);
+    savingCircles.withdraw(baseCircleId);
+
+    // Both claims happened without changing block time (same block in test terms).
+    assertEq(block.timestamp, claimTimestamp);
+
+    assertTrue(savingCircles.hasClaimed(baseCircleId, alice));
+    assertTrue(savingCircles.hasClaimed(baseCircleId, bob));
+    assertEq(token.balanceOf(alice), withdrawAmount);
+    assertEq(token.balanceOf(bob), withdrawAmount);
+  }
+
+  function test_WithdrawSkipToRoundFutureMemberReverts() external {
+    // Complete round 0 deposits so failure is not caused by decommissionability.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
+      vm.stopPrank();
+    }
+
+    // Move to round N = 1 (bob's round). Carol is a future-round member (round 2).
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
+    assertEq(savingCircles.withdrawableBy(baseCircleId), bob);
+
+    vm.prank(carol);
+    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotWithdrawable.selector));
+    savingCircles.withdraw(baseCircleId);
+  }
+
+  function test_WithdrawLateClaimSucceeds() external {
+    // Complete deposits for rounds 0 and 1.
+    // This keeps the circle non-decommissionable while moving far past alice's round 0.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT * 2);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT * 2);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 0
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
+    for (uint256 i = 0; i < members.length; i++) {
+      vm.startPrank(members[i]);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 1
+      vm.stopPrank();
+    }
+
+    // Move well beyond alice's round (current round is 2).
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 2));
+
+    uint256 withdrawAmount = DEPOSIT_AMOUNT * members.length;
+    uint256 aliceBalanceBefore = token.balanceOf(alice);
+
+    vm.prank(alice);
+    savingCircles.withdraw(baseCircleId);
+
+    assertTrue(savingCircles.hasClaimed(baseCircleId, alice));
+    assertEq(token.balanceOf(alice), aliceBalanceBefore + withdrawAmount);
+  }
+
+  function test_WithdrawLateClaimRevertsWhenCircleBecomesDecommissionable() external {
+    // Complete only round 0 so alice's round is fully funded.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 0
+      vm.stopPrank();
+    }
+
+    // Skip to round 2 without completing round 1; circle should be decommissionable.
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 2));
+    assertTrue(savingCircles.isDecommissionable(baseCircleId));
+
+    // Alice is a past-round member with complete round 0 deposits, but claims are blocked when decommissionable.
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotWithdrawable.selector));
+    savingCircles.withdraw(baseCircleId);
+  }
+
+  function test_WithdrawAllMembersOutOfOrderThenCircleDeactivates() external {
+    // Complete deposits for rounds 0, 1, and 2 so every member becomes claimable.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT * 3);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT * 3);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 0
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
+    for (uint256 i = 0; i < members.length; i++) {
+      vm.startPrank(members[i]);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 1
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 2));
+    for (uint256 i = 0; i < members.length; i++) {
+      vm.startPrank(members[i]);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 2
+      vm.stopPrank();
+    }
+
+    // Move past all member rounds; all claims should succeed in any order.
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 3));
+    assertTrue(savingCircles.isActive(baseCircleId));
+
+    // Out-of-order claims: bob (round 1), alice (round 0), carol (round 2).
+    vm.prank(bob);
+    savingCircles.withdraw(baseCircleId);
+    vm.prank(alice);
+    savingCircles.withdraw(baseCircleId);
+    vm.prank(carol);
+    savingCircles.withdraw(baseCircleId);
+
+    assertTrue(savingCircles.hasClaimed(baseCircleId, alice));
+    assertTrue(savingCircles.hasClaimed(baseCircleId, bob));
+    assertTrue(savingCircles.hasClaimed(baseCircleId, carol));
+    assertFalse(savingCircles.isActive(baseCircleId));
+  }
+
   function test_WithdrawWhenUserHasAlreadyClaimed() external {
     // Complete deposits
     vm.mockCall(address(token), abi.encodeWithSelector(IERC20.transferFrom.selector), abi.encode(true));

--- a/test/unit/SavingCirclesViewerUnit.t.sol
+++ b/test/unit/SavingCirclesViewerUnit.t.sol
@@ -216,9 +216,6 @@ contract SavingCirclesViewerUnit is SavingCirclesTestBase {
     savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
     vm.stopPrank();
 
-    // Move time past first round to enable withdrawal
-    vm.warp(block.timestamp + DEPOSIT_INTERVAL);
-
     // Get comprehensive user data for alice (first withdrawer)
     SavingCirclesViewer.ComprehensiveUserData memory userData = savingCirclesViewer.getComprehensiveUserData(alice);
 


### PR DESCRIPTION
This change makes round progression time-based instead of claim-based. The current round is now derived from `block.timestamp`, and claims no longer advance the round. Deposits are tracked per round, deposit windows align to time, and missed rounds can turn the circle decommissionable. The circle ends only after all members have claimed and the contract has no remaining balance.

Key behavior changes

* Round index is derived from time (`effectiveCircleStartTime + depositInterval`) rather than incrementing on claim.
* Deposits are recorded per round (`roundDeposits`) and member balances for UI/queries reflect the current round only.
* Claims no longer advance `currentIndex`; a claim marks the recipient as claimed and can close the circle once all claims are done and funds are distributed.
* If a prior round is incomplete after its window ends, circle becomes decommissionable and deposits for later rounds revert with `CircleStuck`.
* Decommission refunds only unclaimed rounds.

Follow-up / known limitation

`withdrawableBy` and `isWithdrawable` still only expose the current time-based round. Late claimants can still claim (after their round), but the API doesn’t surface them. We may want to change `withdrawableBy` to return a list of claimable members or add a new function to enumerate claimable recipients. Maybe this could be solved in the frontend.

New storage mappings were added: `hasClaimed`, `lastDepositRound`, and `roundDeposits`. If there’s a way to achieve the same behavior without these additions, let me know and I can adjust.