### PR TITLE
Fix decommissioned circle data access in viewer

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -35,6 +35,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable, E
   mapping(uint256 id => mapping(uint256 nonce => bool used)) public usedNonces;
   mapping(uint256 id => bool active) public isActive;
   mapping(uint256 id => address[] members) public circleMembers;
+  mapping(uint256 id => address owner) public circleOwners;
 
   /// @dev Requires circle is commissioned by checking if an owner is set
   modifier onlyCommissioned(uint256 _id) {
@@ -88,6 +89,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable, E
     isMember[_id][owner] = true;
     memberCircles[owner].push(_id);
     circleMembers[_id].push(owner);
+    circleOwners[_id] = owner;
 
     circles[_id] = _circle;
     emit CircleCreated(_id, _circle.token, _circle.depositAmount, _circle.depositInterval);
@@ -153,7 +155,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuard, OwnableUpgradeable, E
       }
     }
 
-    delete circles[_id];
+    circles[_id].owner = address(0);
     emit CircleDecommissioned(_id);
   }
 

--- a/src/contracts/SavingCirclesViewer.sol
+++ b/src/contracts/SavingCirclesViewer.sol
@@ -130,7 +130,7 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
 
     uint256 currentIndex = 0;
     for (uint256 i = 0; i < SAVING_CIRCLES.nextId(); i++) {
-      if (SAVING_CIRCLES.getCircle(i).owner == _user && !_isInArray(i, memberCircleIds)) {
+      if (_getCircleOwner(i) == _user && !_isInArray(i, memberCircleIds)) {
         ownedOnlyIds[currentIndex] = i;
         currentIndex++;
       }
@@ -144,7 +144,7 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
     uint256[] memory memberCircleIds
   ) internal view returns (uint256 count) {
     for (uint256 i = 0; i < SAVING_CIRCLES.nextId(); i++) {
-      if (SAVING_CIRCLES.getCircle(i).owner == _user && !_isInArray(i, memberCircleIds)) {
+      if (_getCircleOwner(i) == _user && !_isInArray(i, memberCircleIds)) {
         count++;
       }
     }
@@ -265,14 +265,19 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
   ) internal view returns (UserCircleData memory circleData) {
     circleData.circleId = _circleId;
 
-    ISavingCircles.Circle memory circle = SAVING_CIRCLES.getCircle(_circleId);
+    ISavingCircles.Circle memory circle = _getCircle(_circleId);
+    bool isDecommissioned = SAVING_CIRCLES.isDecommissioned(circle);
 
-    if (SAVING_CIRCLES.isDecommissioned(circle)) {
+    if (circle.owner == address(0)) {
+      circle.owner = SAVING_CIRCLES.circleOwners(_circleId);
+    }
+    circleData.circleInfo = circle;
+
+    if (isDecommissioned) {
       circleData.isDecommissioned = true;
       return circleData;
     }
 
-    circleData.circleInfo = circle;
     circleData.isDecommissioned = false;
     circleData.isDecommissionable = SAVING_CIRCLES.isDecommissionable(_circleId);
 
@@ -321,7 +326,7 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
 
   function _setDepositProgress(UserCircleData memory circleData, uint256 _circleId) internal view {
     (, uint256[] memory memberBalances) = SAVING_CIRCLES.getMemberBalances(_circleId);
-    ISavingCircles.Circle memory circle = SAVING_CIRCLES.getCircle(_circleId);
+    ISavingCircles.Circle memory circle = _getCircle(_circleId);
 
     uint256 membersWithFullDeposits = 0;
     for (uint256 i = 0; i < memberBalances.length; i++) {
@@ -330,6 +335,36 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
       }
     }
     circleData.remainingDepositsNeeded = memberBalances.length - membersWithFullDeposits;
+  }
+
+  function _getCircleOwner(uint256 _circleId) internal view returns (address owner) {
+    ISavingCircles.Circle memory circle = _getCircle(_circleId);
+    owner = circle.owner;
+    if (owner == address(0)) {
+      owner = SAVING_CIRCLES.circleOwners(_circleId);
+    }
+  }
+
+  function _getCircle(uint256 _circleId) internal view returns (ISavingCircles.Circle memory circle) {
+    (
+      address owner,
+      uint256 currentIndex,
+      uint256 depositAmount,
+      address token,
+      uint256 depositInterval,
+      uint256 effectiveCircleStartTime,
+      uint256 circleEnd
+    ) = SAVING_CIRCLES.circles(_circleId);
+
+    circle = ISavingCircles.Circle({
+      owner: owner,
+      currentIndex: currentIndex,
+      depositAmount: depositAmount,
+      token: token,
+      depositInterval: depositInterval,
+      effectiveCircleStartTime: effectiveCircleStartTime,
+      circleEnd: circleEnd
+    });
   }
 
   function _isInArray(uint256 value, uint256[] memory array) internal pure returns (bool) {

--- a/test/fuzz/SavingCirclesFuzz.t.sol
+++ b/test/fuzz/SavingCirclesFuzz.t.sol
@@ -209,6 +209,13 @@ contract SavingCirclesFuzzTest is SavingCirclesTestBase {
 
     ISavingCircles.Circle memory circle = _defaultCircle(alice, _depositAmount, _depositInterval, address(token));
 
+    if (_depositAmount == 0 && _depositInterval == 0) {
+      vm.prank(alice);
+      vm.expectRevert(ISavingCircles.InvalidDepositInterval.selector);
+      savingCircles.create(circle);
+      return;
+    }
+
     if (_depositAmount == 0) {
       vm.prank(alice);
       vm.expectRevert(ISavingCircles.InvalidDepositAmount.selector);


### PR DESCRIPTION
## Summary
- Keep circle storage on decommission while still marking decommissioned by zeroing `owner`.
- Store the original owner in `circleOwners` so historical data can be displayed.
- Update the viewer to reconstruct circles from raw storage so it won’t revert on decommissioned circles.
- Fix fuzz test expectation for the zero/zero creation edge case.

## Issue
The current `decommission` deletes `circles[_id]` and `getCircle` is guarded by `onlyCommissioned`. This makes `SavingCirclesViewer.getUserCircleData` revert for decommissioned circles, so the frontend can’t show historical circle details. This PR keeps the data and restores viewer access.

## Notes / Possible flaws
- If this upgrade is applied to the existing deployment, older circles won’t have `circleOwners` populated; after decommission, their original owner may be lost unless migrated.
- Storage grows over time because circle records are no longer deleted.
- Viewer now bypasses the `onlyCommissioned` guard by reading raw storage, which is intentional for history but changes the access pattern.

## Alternative approach
- Drop the `owner == address(0)` meaning and add an explicit `isDecommissionedById` flag, optionally storing only a minimal snapshot for display. This is cleaner long‑term but requires changing semantics.
- Alternatively, remove `onlyCommissioned` from `getCircle` and keep circle data; then the viewer can call `getCircle` directly without bypassing the guard.
