### PR TITLE
feat: add member-level withdrawability and fix viewer canWithdraw for late claims

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -296,7 +296,13 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     uint256 currentRound = _currentRoundIndex(_circle);
     if (currentRound >= circleMembers[_id].length) return false;
     address member = circleMembers[_id][currentRound];
-    return _claimable(_id, member);
+    return isMemberWithdrawable(_id, member);
+  }
+
+  /// @inheritdoc ISavingCircles
+  function isMemberWithdrawable(uint256 _id, address _member) public view override returns (bool) {
+    if (!isActive[_id]) return false;
+    return _claimable(_id, _member);
   }
 
   /// @inheritdoc ISavingCircles

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -296,7 +296,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
     address[] memory members = circleMembers[_id];
     for (uint256 i = 0; i < members.length; i++) {
-      if (_claimableWithoutDecommissionCheck(_id, members[i])) return true;
+      if (_activeClaimableCheck(_id, members[i])) return true;
     }
 
     return false;
@@ -391,10 +391,10 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
    */
   function _claimable(uint256 _id, address _member) internal view onlyCommissioned(_id) returns (bool) {
     if (_isDecommissionable(_id)) return false;
-    return _claimableWithoutDecommissionCheck(_id, _member);
+    return _activeClaimableCheck(_id, _member);
   }
 
-  function _claimableWithoutDecommissionCheck(uint256 _id, address _member) internal view returns (bool) {
+  function _activeClaimableCheck(uint256 _id, address _member) internal view returns (bool) {
     Circle memory _circle = circles[_id];
     if (_memberStates[_id][_member].hasClaimed) return false;
 

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -292,10 +292,11 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   /// @inheritdoc ISavingCircles
   function isWithdrawable(uint256 _id) public view override returns (bool) {
     if (!isActive[_id]) return false;
+    if (_isDecommissionable(_id)) return false;
 
     address[] memory members = circleMembers[_id];
     for (uint256 i = 0; i < members.length; i++) {
-      if (_claimable(_id, members[i])) return true;
+      if (_claimableWithoutDecommissionCheck(_id, members[i])) return true;
     }
 
     return false;
@@ -389,9 +390,13 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
    *      Claim eligibility is determined by the time-based round index.
    */
   function _claimable(uint256 _id, address _member) internal view onlyCommissioned(_id) returns (bool) {
+    if (_isDecommissionable(_id)) return false;
+    return _claimableWithoutDecommissionCheck(_id, _member);
+  }
+
+  function _claimableWithoutDecommissionCheck(uint256 _id, address _member) internal view returns (bool) {
     Circle memory _circle = circles[_id];
     if (_memberStates[_id][_member].hasClaimed) return false;
-    if (_isDecommissionable(_id)) return false;
 
     uint256 currentRound = _currentRoundIndex(_circle);
     (uint256 memberIdx, bool found) = _getMemberIndex(_id, _member);

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -292,11 +292,13 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   /// @inheritdoc ISavingCircles
   function isWithdrawable(uint256 _id) public view override returns (bool) {
     if (!isActive[_id]) return false;
-    Circle memory _circle = circles[_id];
-    uint256 currentRound = _currentRoundIndex(_circle);
-    if (currentRound >= circleMembers[_id].length) return false;
-    address member = circleMembers[_id][currentRound];
-    return isMemberWithdrawable(_id, member);
+
+    address[] memory members = circleMembers[_id];
+    for (uint256 i = 0; i < members.length; i++) {
+      if (_claimable(_id, members[i])) return true;
+    }
+
+    return false;
   }
 
   /// @inheritdoc ISavingCircles

--- a/src/contracts/SavingCirclesViewer.sol
+++ b/src/contracts/SavingCirclesViewer.sol
@@ -305,7 +305,7 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
     address currentWithdrawer = SAVING_CIRCLES.currentRoundWithdrawer(_circleId);
     circleData.currentWithdrawer = currentWithdrawer;
     circleData.isCurrentWithdrawer = (currentWithdrawer == _user);
-    circleData.canWithdraw = circleData.isCurrentWithdrawer && SAVING_CIRCLES.isWithdrawable(_circleId);
+    circleData.canWithdraw = SAVING_CIRCLES.isMemberWithdrawable(_circleId, _user);
   }
 
   function _setCircleTimingData(UserCircleData memory circleData, ISavingCircles.Circle memory circle) internal view {

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -341,14 +341,14 @@ interface ISavingCircles {
   function isDecommissionable(uint256 id) external view returns (bool decommissionable);
 
   /**
-   * @notice Check if a circle is withdrawable
+   * @notice Check whether at least one member in a circle can currently claim a withdrawal
    * @param id The ID of the circle
-   * @return withdrawable Whether the circle is withdrawable
+   * @return withdrawable Whether any member in the circle is currently withdrawable
    */
   function isWithdrawable(uint256 id) external view returns (bool withdrawable);
 
   /**
-   * @notice Check if a specific member can withdraw for a circle
+   * @notice Check if a specific member is eligible to claim their withdrawal from a circle
    * @param id The ID of the circle
    * @param member The member to check
    * @return withdrawable Whether the member is withdrawable

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -348,6 +348,14 @@ interface ISavingCircles {
   function isWithdrawable(uint256 id) external view returns (bool withdrawable);
 
   /**
+   * @notice Check if a specific member can withdraw for a circle
+   * @param id The ID of the circle
+   * @param member The member to check
+   * @return withdrawable Whether the member is withdrawable
+   */
+  function isMemberWithdrawable(uint256 id, address member) external view returns (bool withdrawable);
+
+  /**
    * @notice Get the address of the withdrawable by
    * @param id The ID of the circle
    * @return currentRoundWithdrawer The address of the current round withdrawer

--- a/test/fuzz/SavingCirclesMultiRound.t.sol
+++ b/test/fuzz/SavingCirclesMultiRound.t.sol
@@ -529,10 +529,10 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
 
     // Withdrawal
     vm.warp(startTime + (depositInterval * (round + 1)));
-    if (savingCircles.isWithdrawable(circleId)) {
-      ISavingCircles.Circle memory circleData = savingCircles.getCircle(circleId);
-      address[] memory storedMembers = savingCircles.getCircleMembers(circleId);
-      address recipient = storedMembers[circleData.currentIndex];
+    ISavingCircles.Circle memory circleData = savingCircles.getCircle(circleId);
+    address[] memory storedMembers = savingCircles.getCircleMembers(circleId);
+    address recipient = storedMembers[circleData.currentIndex];
+    if (savingCircles.isMemberWithdrawable(circleId, recipient)) {
       vm.prank(recipient);
       savingCircles.withdraw(circleId);
     }

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -194,6 +194,89 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     savingCircles.withdraw(nonExistentCircleId);
   }
 
+  function test_IsMemberWithdrawableReturnsFalseForNonExistentCircle() external view {
+    uint256 nonExistentCircleId = uint256(keccak256(abi.encodePacked('Non Existent Circle')));
+    assertFalse(savingCircles.isMemberWithdrawable(nonExistentCircleId, alice));
+  }
+
+  function test_IsMemberWithdrawableReturnsFalseForInactiveCircle() external {
+    uint256 unstartedCircleId = _createUnstartedCircle();
+    assertFalse(savingCircles.isMemberWithdrawable(unstartedCircleId, alice));
+  }
+
+  function test_IsMemberWithdrawableReturnsFalseForNonMemberWithoutRevert() external view {
+    assertFalse(savingCircles.isMemberWithdrawable(baseCircleId, STRANGER));
+  }
+
+  function test_IsMemberWithdrawableReturnsFalseForFutureRoundMember() external {
+    // Fund round 0 so non-withdrawable status is due to turn ordering, not decommissionability.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL); // round 1
+    assertFalse(savingCircles.isMemberWithdrawable(baseCircleId, carol)); // member index 2
+  }
+
+  function test_IsMemberWithdrawableReturnsFalseAfterMemberAlreadyClaimed() external {
+    // Complete round 0 deposits so alice can claim.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
+    assertTrue(savingCircles.isMemberWithdrawable(baseCircleId, alice));
+
+    vm.prank(alice);
+    savingCircles.withdraw(baseCircleId);
+
+    assertFalse(savingCircles.isMemberWithdrawable(baseCircleId, alice));
+  }
+
+  function test_IsMemberWithdrawableReturnsTrueForLateClaimableMember() external {
+    // Complete rounds 0 and 1 so alice remains claimable in a later round.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT * 2);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT * 2);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 0
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
+    for (uint256 i = 0; i < members.length; i++) {
+      vm.startPrank(members[i]);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 1
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 2)); // round 2
+    assertTrue(savingCircles.isMemberWithdrawable(baseCircleId, alice));
+  }
+
+  function test_IsMemberWithdrawableReturnsFalseWhenDecommissionable() external {
+    // Complete only round 0 then skip round 1 deposits.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 2)); // decommissionable due to missed round 1
+    assertTrue(savingCircles.isDecommissionable(baseCircleId));
+    assertFalse(savingCircles.isMemberWithdrawable(baseCircleId, alice));
+  }
+
   function test_WithdrawWhenUserIsNotACircleMember() external {
     address nonMember = makeAddr('nonMember');
 

--- a/test/unit/SavingCirclesViewerUnit.t.sol
+++ b/test/unit/SavingCirclesViewerUnit.t.sol
@@ -228,6 +228,55 @@ contract SavingCirclesViewerUnit is SavingCirclesTestBase {
     assertFalse(userData.circleData[0].isDecommissionable);
   }
 
+  function test_GetComprehensiveUserDataCanWithdrawForLateClaimablePastRoundMember() external {
+    // Complete rounds 0 and 1 so alice (round 0) remains claimable at round 2.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT * 2);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT * 2);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 0
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + DEPOSIT_INTERVAL);
+    for (uint256 i = 0; i < members.length; i++) {
+      vm.startPrank(members[i]);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT); // round 1
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 2)); // round 2, current withdrawer is carol
+
+    SavingCirclesViewer.ComprehensiveUserData memory userData = savingCirclesViewer.getComprehensiveUserData(alice);
+
+    assertFalse(userData.circleData[0].isCurrentWithdrawer);
+    assertTrue(userData.circleData[0].canWithdraw);
+    assertFalse(userData.circleData[0].isDecommissionable);
+    assertEq(userData.financialSummary.pendingWithdrawals, 1);
+    assertEq(userData.membershipStatus.withdrawableCircleIds.length, 1);
+    assertEq(userData.membershipStatus.withdrawableCircleIds[0], baseCircleId);
+  }
+
+  function test_GetComprehensiveUserDataCanWithdrawFalseWhenLateClaimWouldBeDecommissionable() external {
+    // Complete only round 0 and skip round 1 deposits.
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+      savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
+      vm.stopPrank();
+    }
+
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * 2)); // decommissionable due to incomplete round 1
+
+    SavingCirclesViewer.ComprehensiveUserData memory userData = savingCirclesViewer.getComprehensiveUserData(alice);
+
+    assertTrue(userData.circleData[0].isDecommissionable);
+    assertFalse(userData.circleData[0].canWithdraw);
+    assertEq(userData.financialSummary.pendingWithdrawals, 0);
+    assertEq(userData.membershipStatus.withdrawableCircleIds.length, 0);
+  }
+
   function test_GetComprehensiveUserDataForNonMember() external {
     // Get comprehensive data for a non-member
     SavingCirclesViewer.ComprehensiveUserData memory userData = savingCirclesViewer.getComprehensiveUserData(STRANGER);


### PR DESCRIPTION
We need to change this in order for members to claim late because it fixes the `canWithdraw` from the viewer.

Today, late claims are valid at the contract level (`_claimable` allows a member to claim after their round has passed, as long as their round was fully funded and they have not already claimed), but the viewer only exposed withdrawability for the current round withdrawer. That makes `canWithdraw` incorrect for members who are still eligible to claim from an earlier round.

### What changed
- Added `isMemberWithdrawable(uint256 id, address member)` to `ISavingCircles` and `SavingCircles`
- Updated `SavingCirclesViewer` to compute `UserCircleData.canWithdraw` using `isMemberWithdrawable(circleId, user)` instead of `isCurrentWithdrawer && isWithdrawable(circleId)`
- Updated `isWithdrawable(uint256 id)` to return `true` if **any** member in the circle is claimable (aggregate circle-level status). 
- Updated fuzz test (`SavingCirclesMultiRound`) to use member-specific withdrawability when deciding whether the selected recipient should withdraw

Now:
- `viewer.canWithdraw` reflects whether the user can claim, including late claims
- `isWithdrawable` remains useful as a circle-level “someone can withdraw” signal

### Functions behavior 
- `isWithdrawable(id)`
  - Circle-level check
  - Returns `true` if the circle is active and **at least one member** is currently claimable
  - It no longer means “the current round withdrawer can withdraw”

- `isMemberWithdrawable(id, member)`
  - Member-level check
  - Returns `true` if the circle is active and that specific `member` is claimable right now

- `_claimable(id, member)`
  - Internal source of truth for claim eligibility
  - Returns `false` if the member already claimed or the circle is decommissionable
  - Returns `false` if the member is not in the circle or their turn has not been reached yet (`currentRound < memberIdx`)
  - Returns `true` only when all deposits for that member’s round are complete
  - This enables **late claims** because it allows `currentRound >= memberIdx` (not only `== memberIdx`)

### Test update note
The fuzz test now checks `isMemberWithdrawable(circleId, recipient)` before calling `withdraw`, which matches the actual recipient being tested and avoids relying on the broader circle-level `isWithdrawable` result.