### PR TITLE
Keep decommissioned circles queryable and replace legacy struct-based decommission checks with storage-backed `isDecommissioned`

### DIFF
--- a/src/contracts/DelegatedSavingCircles.sol
+++ b/src/contracts/DelegatedSavingCircles.sol
@@ -113,6 +113,7 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
     for (uint256 id = 0; id < nextId; id++) {
       try SAVING_CIRCLES.getCircle(id) returns (ISavingCircles.Circle memory _circle) {
         if (SAVING_CIRCLES.circleState(id) == ISavingCircles.CircleState.Decommissioned) continue;
+        if (SAVING_CIRCLES.isDecommissionable(id)) continue;
 
         address[] memory circleMembers = SAVING_CIRCLES.getCircleMembers(id);
         // Check if we're in a valid deposit window

--- a/src/contracts/DelegatedSavingCircles.sol
+++ b/src/contracts/DelegatedSavingCircles.sol
@@ -71,8 +71,10 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
     uint256 nextId = SAVING_CIRCLES.nextId();
 
     for (uint256 id = 0; id < nextId; id++) {
-      // Skip if circle doesn't exist or is decommissioned
+      // Skip if circle doesn't exist or can no longer accept deposits.
       try SAVING_CIRCLES.getCircle(id) returns (ISavingCircles.Circle memory _circle) {
+        if (SAVING_CIRCLES.circleState(id) == ISavingCircles.CircleState.Decommissioned) continue;
+
         address[] memory circleMembers = SAVING_CIRCLES.getCircleMembers(id);
         // Check if we're in a valid deposit window
         if (block.timestamp < _circle.effectiveCircleStartTime) continue;
@@ -97,7 +99,7 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
           }
         }
       } catch {
-        // Circle doesn't exist or is decommissioned, skip it
+        // Circle doesn't exist, skip it
         continue;
       }
     }
@@ -110,6 +112,8 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
     uint256 index = 0;
     for (uint256 id = 0; id < nextId; id++) {
       try SAVING_CIRCLES.getCircle(id) returns (ISavingCircles.Circle memory _circle) {
+        if (SAVING_CIRCLES.circleState(id) == ISavingCircles.CircleState.Decommissioned) continue;
+
         address[] memory circleMembers = SAVING_CIRCLES.getCircleMembers(id);
         // Check if we're in a valid deposit window
         if (block.timestamp < _circle.effectiveCircleStartTime) continue;
@@ -151,6 +155,9 @@ contract DelegatedSavingCircles is IDelegatedSavingCircles, ReentrancyGuard {
     if (!delegatedDepositsEnabled[_member]) revert DelegatedDepositsNotEnabled();
 
     if (SAVING_CIRCLES.isDecommissionable(_circleId)) revert ISavingCircles.NotActive();
+    if (SAVING_CIRCLES.circleState(_circleId) == ISavingCircles.CircleState.Decommissioned) {
+      revert ISavingCircles.NotActive();
+    }
 
     // Get circle information
     ISavingCircles.Circle memory _circle = SAVING_CIRCLES.getCircle(_circleId);

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -171,7 +171,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
       }
     }
 
-    delete circles[_id];
     emit CircleDecommissioned(_id);
   }
 

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -44,10 +44,17 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => address[] members) public circleMembers;
   mapping(uint256 id => mapping(address member => MemberState state)) internal _memberStates;
   mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
+  mapping(uint256 id => bool status) public override isDecommissioned;
 
-  /// @dev Requires circle is commissioned by checking if an owner is set
+  /// @dev Requires circle exists and has not been decommissioned
   modifier onlyCommissioned(uint256 _id) {
-    if (_isDecommissioned(circles[_id])) revert NotCommissioned();
+    if (!_exists(_id) || isDecommissioned[_id]) revert NotCommissioned();
+    _;
+  }
+
+  /// @dev Requires circle exists, including retained decommissioned circles
+  modifier onlyExisting(uint256 _id) {
+    if (!_exists(_id)) revert NotCommissioned();
     _;
   }
 
@@ -154,6 +161,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     uint256 membersLength = members.length;
 
     isActive[_id] = false;
+    isDecommissioned[_id] = true;
 
     // Return all funds still held by the contract to the members who deposited them.
     for (uint256 r = 0; r < membersLength; r++) {
@@ -171,6 +179,10 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
       }
     }
 
+    for (uint256 i = 0; i < membersLength; i++) {
+      balances[_id][members[i]] = 0;
+    }
+
     emit CircleDecommissioned(_id);
   }
 
@@ -178,7 +190,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   function redeemInvite(uint256 _id, uint256 _nonce, bytes calldata _signature) external override nonReentrant {
     Circle storage _circle = circles[_id];
 
-    if (_circle.owner == address(0)) revert NotCommissioned();
+    if (_circle.owner == address(0) || isDecommissioned[_id]) revert NotCommissioned();
     if (usedNonces[_id][_nonce]) revert InviteAlreadyUsed();
     if (isMember[_id][msg.sender]) revert AlreadyMember();
     if (isActive[_id]) revert AlreadyActive();
@@ -201,7 +213,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /// @inheritdoc ISavingCircles
-  function getCircle(uint256 _id) external view override onlyCommissioned(_id) returns (Circle memory _circle) {
+  function getCircle(uint256 _id) external view override onlyExisting(_id) returns (Circle memory _circle) {
     _circle = circles[_id];
     _circle.currentIndex = _currentRoundIndex(_circle);
   }
@@ -244,9 +256,9 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     override
     returns (address[] memory _members, uint256[] memory _balances)
   {
-    Circle memory _circle = circles[_id];
+    if (!_exists(_id) || isDecommissioned[_id]) revert NotCommissioned();
 
-    if (_isDecommissioned(_circle)) revert NotCommissioned();
+    Circle memory _circle = circles[_id];
 
     uint256 currentRound = _currentRoundIndex(_circle);
     _balances = new uint256[](circleMembers[_id].length);
@@ -284,11 +296,6 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /// @inheritdoc ISavingCircles
-  function isDecommissioned(Circle calldata _circle) external pure override returns (bool) {
-    return _isDecommissioned(_circle);
-  }
-
-  /// @inheritdoc ISavingCircles
   function isWithdrawable(uint256 _id) public view override returns (bool) {
     if (!isActive[_id]) return false;
     if (_isDecommissionable(_id)) return false;
@@ -308,8 +315,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /// @inheritdoc ISavingCircles
-  function currentRoundWithdrawer(uint256 _id) public view override onlyCommissioned(_id) returns (address) {
-    if (!isActive[_id]) return address(0);
+  function currentRoundWithdrawer(uint256 _id) public view override onlyExisting(_id) returns (address) {
+    if (isDecommissioned[_id] || !isActive[_id]) return address(0);
     Circle memory _circle = circles[_id];
 
     uint256 currentRound = _currentRoundIndex(_circle);
@@ -318,9 +325,11 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /// @inheritdoc ISavingCircles
-  function circleState(uint256 _id) public view override onlyCommissioned(_id) returns (CircleState state) {
+  function circleState(uint256 _id) public view override onlyExisting(_id) returns (CircleState state) {
     Circle memory _circle = circles[_id];
-    if (isActive[_id]) {
+    if (isDecommissioned[_id]) {
+      state = CircleState.Decommissioned;
+    } else if (isActive[_id]) {
       state = CircleState.Active;
       uint256 currentRound = _currentRoundIndex(_circle);
       if (currentRound >= circleMembers[_id].length) {
@@ -338,16 +347,14 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
           state = CircleState.DepositComplete;
         }
       }
-    } else if (_isDecommissioned(_circle)) {
-      state = CircleState.Decommissioned;
     } else {
       state = CircleState.NotStarted;
     }
   }
 
   /// @inheritdoc ISavingCircles
-  function roundState(uint256 _id) public view override onlyCommissioned(_id) returns (RoundState state) {
-    if (!isActive[_id]) return RoundState.NotStarted;
+  function roundState(uint256 _id) public view override onlyExisting(_id) returns (RoundState state) {
+    if (isDecommissioned[_id] || !isActive[_id]) return RoundState.NotStarted;
 
     Circle memory _circle = circles[_id];
     uint256 currentRound = _currentRoundIndex(_circle);
@@ -461,6 +468,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
    *      and that round must have incomplete deposits.
    */
   function _isDecommissionable(uint256 _id) internal view returns (bool) {
+    if (!_exists(_id) || isDecommissioned[_id] || !isActive[_id]) return false;
+
     Circle memory _circle = circles[_id];
     uint256 len = circleMembers[_id].length;
     if (len == 0) return false;
@@ -517,11 +526,8 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     return true;
   }
 
-  /**
-   * @dev Return if a specified circle is decommissioned by checking if an owner is set
-   */
-  function _isDecommissioned(Circle memory _circle) internal pure returns (bool) {
-    return _circle.owner == address(0);
+  function _exists(uint256 _id) internal view returns (bool) {
+    return circles[_id].owner != address(0);
   }
 
   function _roundEndTime(Circle memory _circle, uint256 round) internal pure returns (uint256) {

--- a/src/contracts/SavingCirclesViewer.sol
+++ b/src/contracts/SavingCirclesViewer.sol
@@ -301,8 +301,9 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
 
     if (SAVING_CIRCLES.circleState(_circleId) == ISavingCircles.CircleState.Decommissioned) {
       circleData.isDecommissioned = true;
-      circleData.completedRounds = circle.currentIndex;
       circleData.totalRounds = SAVING_CIRCLES.getCircleMembers(_circleId).length;
+      circleData.completedRounds =
+        circle.currentIndex > circleData.totalRounds ? circleData.totalRounds : circle.currentIndex;
       return circleData;
     }
 

--- a/src/contracts/SavingCirclesViewer.sol
+++ b/src/contracts/SavingCirclesViewer.sol
@@ -116,8 +116,11 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
         states[i].circleState = ISavingCircles.CircleState.Decommissioned;
         states[i].roundState = ISavingCircles.RoundState.NotStarted;
       } else {
-        states[i].circleState = SAVING_CIRCLES.circleState(circleId);
-        states[i].roundState = SAVING_CIRCLES.roundState(circleId);
+        ISavingCircles.CircleState circleState = SAVING_CIRCLES.circleState(circleId);
+        states[i].circleState = circleState;
+        states[i].roundState = circleState == ISavingCircles.CircleState.Decommissioned
+          ? ISavingCircles.RoundState.NotStarted
+          : SAVING_CIRCLES.roundState(circleId);
       }
     }
     return states;
@@ -291,6 +294,16 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
     }
 
     circleData.circleInfo = circle;
+    circleData.isOwner = (circle.owner == _user);
+    circleData.isMember = SAVING_CIRCLES.isMember(_circleId, _user);
+
+    if (SAVING_CIRCLES.circleState(_circleId) == ISavingCircles.CircleState.Decommissioned) {
+      circleData.isDecommissioned = true;
+      circleData.completedRounds = circle.currentIndex;
+      circleData.totalRounds = SAVING_CIRCLES.getCircleMembers(_circleId).length;
+      return circleData;
+    }
+
     circleData.isDecommissioned = false;
     circleData.isDecommissionable = SAVING_CIRCLES.isDecommissionable(_circleId);
 
@@ -356,6 +369,10 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
 
   function _memberBalance(uint256 _circleId, address _member) internal view returns (uint256) {
     if (_getCircleOwner(_circleId) == address(0)) {
+      return 0;
+    }
+
+    if (SAVING_CIRCLES.circleState(_circleId) == ISavingCircles.CircleState.Decommissioned) {
       return 0;
     }
 

--- a/src/contracts/SavingCirclesViewer.sol
+++ b/src/contracts/SavingCirclesViewer.sol
@@ -183,7 +183,9 @@ contract SavingCirclesViewer is ISavingCirclesViewer {
       UserCircleData memory circleData = _getUserCircleData(_user, circleId);
 
       if (!circleData.isDecommissioned) {
-        summary.activeCirclesCount++;
+        if (!circleData.isExpired) {
+          summary.activeCirclesCount++;
+        }
 
         if (circleData.isOwner) {
           summary.ownedCirclesCount++;

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -353,10 +353,10 @@ interface ISavingCircles {
 
   /**
    * @notice Check if a circle is decommissioned
-   * @param circle The circle
+   * @param id The ID of the circle
    * @return decommissioned Whether the circle is decommissioned
    */
-  function isDecommissioned(Circle memory circle) external view returns (bool decommissioned);
+  function isDecommissioned(uint256 id) external view returns (bool decommissioned);
 
   /**
    * @notice Check if a circle is decommissionable

--- a/test/fuzz/SavingCirclesFuzz.t.sol
+++ b/test/fuzz/SavingCirclesFuzz.t.sol
@@ -197,8 +197,9 @@ contract SavingCirclesFuzzTest is SavingCirclesTestBase {
       assertEq(token.balanceOf(members[i]), _depositAmount / 2);
     }
 
-    vm.expectRevert(ISavingCircles.NotCommissioned.selector);
-    savingCircles.getCircle(circleId);
+    assertEq(savingCircles.getCircle(circleId).owner, alice);
+    assertEq(uint256(savingCircles.circleState(circleId)), uint256(ISavingCircles.CircleState.Decommissioned));
+    assertFalse(savingCircles.isDecommissionable(circleId));
   }
 
   function testFuzz_InvalidCircleCreation_ZeroValues(uint256 _depositAmount, uint256 _depositInterval) public {

--- a/test/fuzz/SavingCirclesMultiRound.t.sol
+++ b/test/fuzz/SavingCirclesMultiRound.t.sol
@@ -262,9 +262,10 @@ contract SavingCirclesMultiRoundFuzzTest is SavingCirclesTestBase {
       assertEq(token.balanceOf(members[i]), balancesBefore[i]);
     }
 
-    // Circle should be decommissioned
-    vm.expectRevert(ISavingCircles.NotCommissioned.selector);
-    savingCircles.getCircle(circleId);
+    // Circle should remain queryable but decommissioned
+    assertEq(savingCircles.getCircle(circleId).owner, alice);
+    assertEq(uint256(savingCircles.circleState(circleId)), uint256(ISavingCircles.CircleState.Decommissioned));
+    assertFalse(savingCircles.isDecommissionable(circleId));
   }
 
   function testFuzz_SequentialCirclesWithSameMembers(

--- a/test/integration/SavingCircles.t.sol
+++ b/test/integration/SavingCircles.t.sol
@@ -190,9 +190,10 @@ contract SavingCirclesIntegration is IntegrationBase {
     assertEq(token.balanceOf(alice) - aliceBalanceBefore, DEPOSIT_AMOUNT);
     assertEq(token.balanceOf(bob) - bobBalanceBefore, DEPOSIT_AMOUNT);
 
-    // Check circle deleted
-    vm.expectRevert(ISavingCircles.NotCommissioned.selector);
-    circle.getCircle(baseCircleId);
+    // Check circle remains queryable but is decommissioned
+    assertEq(circle.getCircle(baseCircleId).owner, alice);
+    assertEq(uint256(circle.circleState(baseCircleId)), uint256(ISavingCircles.CircleState.Decommissioned));
+    assertFalse(circle.isDecommissionable(baseCircleId));
   }
 
   function test_MemberDecommissionWhenIncompleteDeposits() public {
@@ -217,9 +218,10 @@ contract SavingCirclesIntegration is IntegrationBase {
     // Check Alice got her deposit back
     assertEq(token.balanceOf(alice) - aliceBalanceBefore, DEPOSIT_AMOUNT);
 
-    // Check circle was deleted
-    vm.expectRevert(ISavingCircles.NotCommissioned.selector);
-    circle.getCircle(baseCircleId);
+    // Check circle remains queryable but is decommissioned
+    assertEq(circle.getCircle(baseCircleId).owner, alice);
+    assertEq(uint256(circle.circleState(baseCircleId)), uint256(ISavingCircles.CircleState.Decommissioned));
+    assertFalse(circle.isDecommissionable(baseCircleId));
   }
 
   function test_RevertWhen_NotEnoughContributions() public {

--- a/test/invariants/SavingCirclesInvariants.t.sol
+++ b/test/invariants/SavingCirclesInvariants.t.sol
@@ -100,12 +100,16 @@ contract SavingCirclesInvariantsTest is StdInvariant, Test {
     }
   }
 
-  function invariant_DecommissionedCirclesAreEmpty() public {
+  function invariant_DecommissionedCirclesRemainClosed() public view {
     uint256[] memory decommissionedIds = handler.getDecommissionedCircles();
 
     for (uint256 i = 0; i < decommissionedIds.length; i++) {
-      vm.expectRevert(ISavingCircles.NotCommissioned.selector);
-      savingCircles.getCircle(decommissionedIds[i]);
+      uint256 circleId = decommissionedIds[i];
+
+      assertEq(uint256(savingCircles.circleState(circleId)), uint256(ISavingCircles.CircleState.Decommissioned));
+      assertEq(savingCircles.currentRoundWithdrawer(circleId), address(0));
+      assertFalse(savingCircles.isActive(circleId));
+      assertFalse(savingCircles.isDecommissionable(circleId));
     }
   }
 

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -650,8 +650,11 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     savingCircles.decommission(baseCircleId);
     vm.stopPrank();
 
-    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotCommissioned.selector));
-    savingCircles.getCircle(baseCircleId);
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    assertEq(circle.owner, alice);
+    assertFalse(savingCircles.isActive(baseCircleId));
+    assertFalse(savingCircles.isDecommissionable(baseCircleId));
+    assertEq(uint256(savingCircles.circleState(baseCircleId)), uint256(ISavingCircles.CircleState.Decommissioned));
   }
 
   function test_DecommissionWhenMemberAndIncompleteDeposits() external {
@@ -671,9 +674,11 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     emit ISavingCircles.CircleDecommissioned(baseCircleId);
     savingCircles.decommission(baseCircleId);
 
-    // Verify circle was deleted
-    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotCommissioned.selector));
-    savingCircles.getCircle(baseCircleId);
+    // Verify circle remains queryable for the UI but is marked decommissioned
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    assertEq(circle.owner, alice);
+    assertEq(uint256(savingCircles.circleState(baseCircleId)), uint256(ISavingCircles.CircleState.Decommissioned));
+    assertFalse(savingCircles.isDecommissionable(baseCircleId));
 
     // Verify alice got her deposit back
     assertEq(token.balanceOf(alice), DEPOSIT_AMOUNT);
@@ -1201,8 +1206,9 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     savingCircles.decommission(circleId);
 
     // State 5: Decommissioned (final state)
-    vm.expectRevert(ISavingCircles.NotCommissioned.selector);
-    savingCircles.getCircle(circleId);
+    assertEq(uint256(savingCircles.circleState(circleId)), uint256(ISavingCircles.CircleState.Decommissioned));
+    assertFalse(savingCircles.isDecommissionable(circleId));
+    assertEq(savingCircles.getCircle(circleId).owner, alice);
   }
 
   // ============ Circle/Round View State Tests ============
@@ -1241,8 +1247,8 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     vm.prank(alice);
     savingCircles.decommission(baseCircleId);
 
-    vm.expectRevert(abi.encodeWithSelector(ISavingCircles.NotCommissioned.selector));
-    savingCircles.circleState(baseCircleId);
+    assertEq(uint256(savingCircles.circleState(baseCircleId)), uint256(ISavingCircles.CircleState.Decommissioned));
+    assertEq(uint256(savingCircles.roundState(baseCircleId)), uint256(ISavingCircles.RoundState.NotStarted));
   }
 
   function test_RoundStateWhenRoundHasNotStartedYet() external {

--- a/test/unit/SavingCirclesViewerUnit.t.sol
+++ b/test/unit/SavingCirclesViewerUnit.t.sol
@@ -364,6 +364,22 @@ contract SavingCirclesViewerUnit is SavingCirclesTestBase {
     assertEq(userData.financialSummary.completedCirclesCount, 1);
   }
 
+  function test_GetComprehensiveUserDataHandlesExpiredCircle() external {
+    vm.warp(baseCircleStart + (DEPOSIT_INTERVAL * members.length));
+
+    SavingCirclesViewer.ComprehensiveUserData memory userData = savingCirclesViewer.getComprehensiveUserData(alice);
+
+    assertEq(userData.membershipStatus.allCircleIds.length, 1);
+    assertEq(userData.membershipStatus.expiredCircleIds.length, 1);
+    assertEq(userData.membershipStatus.expiredCircleIds[0], baseCircleId);
+
+    assertEq(userData.circleData.length, 1);
+    assertTrue(userData.circleData[0].isExpired);
+    assertFalse(userData.circleData[0].isDecommissioned);
+
+    assertEq(userData.financialSummary.activeCirclesCount, 0);
+  }
+
   function test_GetCirclesStateHandlesDecommissionedCircle() external {
     vm.warp(baseCircleStart + DEPOSIT_INTERVAL + 1);
     vm.prank(alice);

--- a/test/unit/SavingCirclesViewerUnit.t.sol
+++ b/test/unit/SavingCirclesViewerUnit.t.sol
@@ -355,6 +355,9 @@ contract SavingCirclesViewerUnit is SavingCirclesTestBase {
 
     assertEq(userData.circleData.length, 1);
     assertTrue(userData.circleData[0].isDecommissioned);
+    assertEq(userData.circleData[0].circleInfo.owner, alice);
+    assertTrue(userData.circleData[0].isMember);
+    assertFalse(userData.circleData[0].isDecommissionable);
 
     assertEq(userData.financialSummary.totalBalance, 0);
     assertEq(userData.financialSummary.activeCirclesCount, 0);


### PR DESCRIPTION
## Summary

This PR reworks decommission handling so circles are no longer deleted from storage when they are decommissioned. Instead, a circle is explicitly marked as decommissioned via a dedicated `isDecommissioned[id]` storage flag and remains queryable for UI and historical read purposes.

The change also removes the old `isDecommissioned(Circle)` API, which inferred decommission status from `owner == address(0)`. That approach no longer matched the intended behavior once decommissioned circles were retained in storage. The new source of truth is the storage-backed `isDecommissioned(uint256 id)` getter.

## Problem

The previous implementation mixed two incompatible models:

- Historically, decommissioning meant deleting the circle from storage.
- The newer UI requirement is to keep decommissioned circles readable after decommission so they can still be shown to users.

That exposed an inconsistency in the old decommission checks:

- `isDecommissioned(Circle)` only checked whether `circle.owner == address(0)`.
- Once circles stopped being deleted, decommissioned circles still had a valid owner.
- As a result, decommissioned circles could remain readable for the UI, but the contract’s legacy “decommissioned” check no longer reflected reality.

## What Changed

### Core contract changes

- Added a dedicated storage-backed decommission flag: `isDecommissioned[id]`.
- Removed the legacy `isDecommissioned(Circle)` function and its internal owner-based implementation.
- Updated the interface so decommission state is queried by `id`, not by passing a `Circle` struct.
- Kept decommissioned circles in storage instead of deleting them.
- Introduced an `onlyExisting` read gate for paths that should allow historical access to retained circles.
- Updated `onlyCommissioned` to mean:
  - the circle exists, and
  - the circle has not been decommissioned.
- On decommission:
  - mark the circle as decommissioned,
  - mark it inactive,
  - refund any remaining round deposits,
  - zero the stored member balances for that circle.

### Read-path behavior updates

- `getCircle(id)` now works for decommissioned circles as long as the circle exists.
- `circleState(id)` now returns `Decommissioned` for retained decommissioned circles.
- `roundState(id)` returns `NotStarted` for decommissioned circles.
- `currentRoundWithdrawer(id)` returns `address(0)` for decommissioned circles.
- `getMemberBalances(id)` still rejects decommissioned circles, preserving the rule that no active deposit state should be exposed once a circle is closed.

### Viewer updates

- Updated viewer logic to treat decommissioned circles as retained historical records rather than missing/deleted circles.
- `getCirclesState` now correctly reports `Decommissioned` without trying to read round state from a closed circle.
- Comprehensive user data now includes decommissioned circles with their retained metadata.
- Total balance and member balance aggregation explicitly ignore decommissioned circles.

### Delegated deposit updates

- Delegated deposit discovery now skips circles whose state is `Decommissioned`.
- Delegated deposit execution rejects decommissioned circles even if the circle record still exists.

## API Changes

### Removed

- `isDecommissioned(Circle memory circle)`

### Added / Replaced

- `isDecommissioned(uint256 id)`

This is a breaking interface change for any external caller that relied on the old struct-based API.

## Behavioral Impact

After this PR:

- Decommissioned circles remain queryable for UI and historical purposes.
- Decommissioned circles are explicitly closed via contract state, not inferred from deleted storage.
- Closed circles cannot be treated as commissioned/active circles for deposits, withdrawals, invites, or delegated deposit flows.
- Consumers can determine decommission status directly from `isDecommissioned(id)` or `circleState(id)`.

## Tests

Updated unit, integration, fuzz, and invariant coverage to reflect the new retained-circle behavior:

- unit tests now assert that decommissioned circles remain queryable and report `Decommissioned`
- viewer tests now assert that decommissioned circles appear correctly in user data
- integration and fuzz tests now verify retained access plus closed-state behavior
- invariant coverage now checks that decommissioned circles remain closed rather than assuming they are deleted

## Why this approach

This keeps the contract model aligned with the product requirement:

- the UI needs historical visibility into decommissioned circles
- protocol logic still needs a strict closed-state boundary

Using a dedicated storage flag makes that distinction explicit, removes ambiguous owner-based inference, and keeps the read/write semantics coherent across the core contract, viewer layer, and delegated deposit flows.