### PR TITLE
refactor: use currentIndex sentinel instead of isDecommissioned mapping

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -44,11 +44,12 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   mapping(uint256 id => address[] members) public circleMembers;
   mapping(uint256 id => mapping(address member => MemberState state)) internal _memberStates;
   mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) public roundDeposits;
-  mapping(uint256 id => bool status) public override isDecommissioned;
+
+  uint256 public constant DECOMMISSIONED_SENTINEL = type(uint256).max;
 
   /// @dev Requires circle exists and has not been decommissioned
   modifier onlyCommissioned(uint256 _id) {
-    if (!_exists(_id) || isDecommissioned[_id]) revert NotCommissioned();
+    if (!_exists(_id) || _isDecommissionedCheck(_id)) revert NotCommissioned();
     _;
   }
 
@@ -161,7 +162,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     uint256 membersLength = members.length;
 
     isActive[_id] = false;
-    isDecommissioned[_id] = true;
+    circles[_id].currentIndex = DECOMMISSIONED_SENTINEL;
 
     // Return all funds still held by the contract to the members who deposited them.
     for (uint256 r = 0; r < membersLength; r++) {
@@ -190,7 +191,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   function redeemInvite(uint256 _id, uint256 _nonce, bytes calldata _signature) external override nonReentrant {
     Circle storage _circle = circles[_id];
 
-    if (_circle.owner == address(0) || isDecommissioned[_id]) revert NotCommissioned();
+    if (_circle.owner == address(0) || circles[_id].currentIndex == DECOMMISSIONED_SENTINEL) revert NotCommissioned();
     if (usedNonces[_id][_nonce]) revert InviteAlreadyUsed();
     if (isMember[_id][msg.sender]) revert AlreadyMember();
     if (isActive[_id]) revert AlreadyActive();
@@ -256,7 +257,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     override
     returns (address[] memory _members, uint256[] memory _balances)
   {
-    if (!_exists(_id) || isDecommissioned[_id]) revert NotCommissioned();
+    if (!_exists(_id) || _isDecommissionedCheck(_id)) revert NotCommissioned();
 
     Circle memory _circle = circles[_id];
 
@@ -316,7 +317,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
   /// @inheritdoc ISavingCircles
   function currentRoundWithdrawer(uint256 _id) public view override onlyExisting(_id) returns (address) {
-    if (isDecommissioned[_id] || !isActive[_id]) return address(0);
+    if (_isDecommissionedCheck(_id) || !isActive[_id]) return address(0);
     Circle memory _circle = circles[_id];
 
     uint256 currentRound = _currentRoundIndex(_circle);
@@ -327,7 +328,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   /// @inheritdoc ISavingCircles
   function circleState(uint256 _id) public view override onlyExisting(_id) returns (CircleState state) {
     Circle memory _circle = circles[_id];
-    if (isDecommissioned[_id]) {
+    if (_isDecommissionedCheck(_id)) {
       state = CircleState.Decommissioned;
     } else if (isActive[_id]) {
       state = CircleState.Active;
@@ -354,7 +355,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
   /// @inheritdoc ISavingCircles
   function roundState(uint256 _id) public view override onlyExisting(_id) returns (RoundState state) {
-    if (isDecommissioned[_id] || !isActive[_id]) return RoundState.NotStarted;
+    if (_isDecommissionedCheck(_id) || !isActive[_id]) return RoundState.NotStarted;
 
     Circle memory _circle = circles[_id];
     uint256 currentRound = _currentRoundIndex(_circle);
@@ -468,7 +469,7 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
    *      and that round must have incomplete deposits.
    */
   function _isDecommissionable(uint256 _id) internal view returns (bool) {
-    if (!_exists(_id) || isDecommissioned[_id] || !isActive[_id]) return false;
+    if (!_exists(_id) || _isDecommissionedCheck(_id) || !isActive[_id]) return false;
 
     Circle memory _circle = circles[_id];
     uint256 len = circleMembers[_id].length;
@@ -528,6 +529,15 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
   function _exists(uint256 _id) internal view returns (bool) {
     return circles[_id].owner != address(0);
+  }
+
+  /// @inheritdoc ISavingCircles
+  function isDecommissioned(uint256 _id) external view override returns (bool) {
+    return _isDecommissionedCheck(_id);
+  }
+
+  function _isDecommissionedCheck(uint256 _id) internal view returns (bool) {
+    return circles[_id].currentIndex == DECOMMISSIONED_SENTINEL;
   }
 
   function _roundEndTime(Circle memory _circle, uint256 round) internal pure returns (uint256) {


### PR DESCRIPTION
## Summary
- Replaces the `isDecommissioned` boolean mapping with a sentinel value (`type(uint256).max`) on the existing `currentIndex` field of the Circle struct
- Avoids adding new storage while preserving identical external behavior — `isDecommissioned(uint256)` remains callable as a view function
- All 141 tests pass

## Changes
- Removed `mapping(uint256 id => bool status) isDecommissioned`
- Added `DECOMMISSIONED_SENTINEL` constant (`type(uint256).max`)
- On decommission, sets `circles[_id].currentIndex = DECOMMISSIONED_SENTINEL` instead of `isDecommissioned[_id] = true`
- Added `_isDecommissionedCheck()` internal helper and `isDecommissioned()` public view function
- `getCircle()` still returns the computed round index (not the sentinel) since `_currentRoundIndex()` doesn't read `currentIndex`

## Test plan
- [x] All existing tests pass (141/141)
- [x] Build succeeds