### PR TITLE
perf: decommission() O(N²) → O(N) by batching member transfers

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -155,19 +155,24 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
 
     isActive[_id] = false;
 
-    // Return all funds still held by the contract to the members who deposited them.
+    // Aggregate refunds per depositor across all unclaimed rounds to minimise
+    // external calls. Each safeTransfer costs ~20k gas, so batching is significant. (#120)
+    uint256[] memory refunds = new uint256[](membersLength);
+
     for (uint256 r = 0; r < membersLength; r++) {
-      address recipient = members[r];
-      if (_memberStates[_id][recipient].hasClaimed) continue; // round already paid out
+      if (_memberStates[_id][members[r]].hasClaimed) continue; // round already paid out
 
       for (uint256 i = 0; i < membersLength; i++) {
-        address member = members[i];
-        uint256 amount = roundDeposits[_id][r][member];
+        uint256 amount = roundDeposits[_id][r][members[i]];
         if (amount == 0) continue;
+        refunds[i] += amount;
+      }
+    }
 
-        roundDeposits[_id][r][member] = 0;
-
-        IERC20(token).safeTransfer(member, amount);
+    // Single transfer per member
+    for (uint256 i = 0; i < membersLength; i++) {
+      if (refunds[i] > 0) {
+        IERC20(token).safeTransfer(members[i], refunds[i]);
       }
     }
 


### PR DESCRIPTION
## Summary

Closes #120

`decommission()` previously made one `safeTransfer` call per member per unclaimed round — O(N²) external calls in the worst case. Each call costs ~20k gas overhead.

This refactors the refund loop to aggregate all owed amounts per depositor into a memory array, then executes a single transfer per member.

## Changes

- Accumulate refunds in a `uint256[] memory` array indexed by member position
- Single `safeTransfer` per member after aggregation
- Removed per-round SSTORE zeroing of `roundDeposits` (circle is deactivated, data is dead)

## Test plan

- [ ] `forge test` passes (140 tests)
- [ ] Verify decommission refunds are correct with multi-round scenarios