### PR TITLE
chore: add OZ-standard storage gap to SavingCircles

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -537,4 +537,12 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
     bytes32 _structHash = keccak256(abi.encode(_INVITE_TYPEHASH, _id, _nonce));
     return _hashTypedDataV4(_structHash);
   }
+
+  /**
+   * @dev Reserved storage gap for future upgrades.
+   *      Follows the OpenZeppelin upgradeable contract convention of reserving
+   *      50 storage slots so that new state variables can be added in future
+   *      implementation versions without shifting existing storage layout.
+   */
+  uint256[50] private __gap;
 }


### PR DESCRIPTION
## Summary

Closes #129

Adds `uint256[50] private __gap` following the OpenZeppelin upgradeable contract convention. This reserves 50 storage slots so future implementation versions can add state variables without breaking deployed storage layout.

## Changes

- `SavingCircles.sol`: added `uint256[50] private __gap` at the end of the contract

## Test plan

- [ ] `forge test` passes (140 tests)
- [ ] `forge inspect SavingCircles storage-layout` shows __gap at expected slot offset