### PR TITLE
docs: mark isWithdrawable() as deprecated

### DIFF
--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -290,6 +290,10 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /// @inheritdoc ISavingCircles
+  /// @dev @deprecated O(N²) gas cost: iterates all members and for each calls _activeClaimableCheck,
+  ///   which itself calls _allMembersDepositedForRound (another O(N) scan). Prefer
+  ///   isMemberWithdrawable(_id, member) for O(N) per-member checks, or currentRoundWithdrawer(_id)
+  ///   for O(1) lookup of the current round's designated recipient.
   function isWithdrawable(uint256 _id) public view override returns (bool) {
     if (!isActive[_id]) return false;
     if (_isDecommissionable(_id)) return false;

--- a/src/interfaces/ISavingCircles.sol
+++ b/src/interfaces/ISavingCircles.sol
@@ -367,6 +367,11 @@ interface ISavingCircles {
 
   /**
    * @notice Check whether at least one member in a circle can currently claim a withdrawal
+   * @dev @deprecated This function has O(N²) gas cost: it iterates all members and for each
+   *   calls an inner check that itself iterates all members to verify deposits. Use
+   *   `isMemberWithdrawable(id, member)` for per-member checks or `currentRoundWithdrawer(id)`
+   *   to identify the current round's designated recipient. This function is retained for
+   *   backward compatibility and will be removed in the next breaking release.
    * @param id The ID of the circle
    * @return withdrawable Whether any member in the circle is currently withdrawable
    */


### PR DESCRIPTION
## Summary

Closes #126

Marks `isWithdrawable()` as `@deprecated` in both `ISavingCircles` interface and `SavingCircles` implementation.

The function has O(N²) gas cost — it iterates all members and for each calls `_activeClaimableCheck`, which itself scans all members. The deprecation notice directs callers to:

- `isMemberWithdrawable(id, member)` for per-member O(N) checks
- `currentRoundWithdrawer(id)` for O(1) lookup of the current round's recipient

Function retained for backward compatibility; removal planned for the next breaking release.

## Changes

- `ISavingCircles.sol`: added `@dev @deprecated` NatSpec with migration guidance
- `SavingCircles.sol`: added matching `@dev @deprecated` NatSpec

## Test plan

- [ ] `forge test` passes (140 tests)
- [ ] Documentation-only change — no behavioral impact