### PR TITLE
Automatic claims

### DIFF
--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -118,32 +118,22 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
 
   /// @inheritdoc IAutomaticSavingCircles
   function depositChecker() external view override returns (bool canExec, bytes memory execPayload) {
-    uint256[] memory circleIds;
-    address[] memory members;
+    if (automationExecutor == address(0)) return (false, bytes(''));
 
-    if (automationExecutor != address(0)) {
-      (circleIds, members) = getEligibleAutomatedDeposits();
-      canExec = circleIds.length > 0;
-    } else {
-      circleIds = new uint256[](0);
-      members = new address[](0);
-    }
+    (uint256[] memory circleIds, address[] memory members) = getEligibleAutomatedDeposits();
+    canExec = circleIds.length > 0;
+    if (!canExec) return (false, bytes(''));
 
     execPayload = abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedDeposits, (circleIds, members));
   }
 
   /// @inheritdoc IAutomaticSavingCircles
   function claimChecker() external view override returns (bool canExec, bytes memory execPayload) {
-    uint256[] memory circleIds;
-    address[] memory members;
+    if (automationExecutor == address(0)) return (false, bytes(''));
 
-    if (automationExecutor != address(0)) {
-      (circleIds, members) = getEligibleAutomatedClaims();
-      canExec = circleIds.length > 0;
-    } else {
-      circleIds = new uint256[](0);
-      members = new address[](0);
-    }
+    (uint256[] memory circleIds, address[] memory members) = getEligibleAutomatedClaims();
+    canExec = circleIds.length > 0;
+    if (!canExec) return (false, bytes(''));
 
     execPayload = abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedClaims, (circleIds, members));
   }

--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -118,10 +118,8 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
 
   /// @inheritdoc IAutomaticSavingCircles
   function depositChecker() external view override returns (bool canExec, bytes memory execPayload) {
-    if (automationExecutor == address(0)) return (false, bytes(''));
-
     (uint256[] memory circleIds, address[] memory members) = getEligibleAutomatedDeposits();
-    canExec = circleIds.length > 0;
+    canExec = _automationCanExecute(circleIds);
     if (!canExec) return (false, bytes(''));
 
     execPayload = abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedDeposits, (circleIds, members));
@@ -129,10 +127,8 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
 
   /// @inheritdoc IAutomaticSavingCircles
   function claimChecker() external view override returns (bool canExec, bytes memory execPayload) {
-    if (automationExecutor == address(0)) return (false, bytes(''));
-
     (uint256[] memory circleIds, address[] memory members) = getEligibleAutomatedClaims();
-    canExec = circleIds.length > 0;
+    canExec = _automationCanExecute(circleIds);
     if (!canExec) return (false, bytes(''));
 
     execPayload = abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedClaims, (circleIds, members));
@@ -182,6 +178,15 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     for (uint256 circleId = 0; circleId < circleCount; circleId++) {
       index = _appendEligibleAutomatedClaimsForCircle(circleId, circleIds, members, index);
     }
+  }
+
+  /**
+   * @dev Returns whether Gelato automation can execute for the selected targets
+   * @param _circleIds Circle IDs selected for automated execution
+   * @return Whether an automation executor is configured and at least one target exists
+   */
+  function _automationCanExecute(uint256[] memory _circleIds) internal view returns (bool) {
+    return automationExecutor != address(0) && _circleIds.length > 0;
   }
 
   /**

--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -190,7 +190,7 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
 
     uint256 index = 0;
     for (uint256 circleId = 0; circleId < circleCount; circleId++) {
-      index = _populateEligibleAutomatedClaimsForCircle(circleId, circleIds, members, index);
+      index = _appendEligibleAutomatedClaimsForCircle(circleId, circleIds, members, index);
     }
   }
 
@@ -374,7 +374,7 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
    * @param _index Current write index in the output arrays
    * @return nextIndex Updated write index after appending any eligible targets
    */
-  function _populateEligibleAutomatedClaimsForCircle(
+  function _appendEligibleAutomatedClaimsForCircle(
     uint256 _circleId,
     uint256[] memory _circleIds,
     address[] memory _members,

--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -72,6 +72,15 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     _executeAutomatedDepositTarget(_circleId, _member);
   }
 
+  /**
+   * @dev External trampoline used to isolate single-target failures with try/catch during batch claim execution
+   * @param _circleId Circle to process
+   * @param _member Member to claim for
+   */
+  function executeAutomatedClaimTarget(uint256 _circleId, address _member) external onlySelf {
+    _executeAutomatedClaimTarget(_circleId, _member);
+  }
+
   /// @inheritdoc IAutomaticSavingCircles
   function batchExecuteAutomatedDeposits(
     uint256[] calldata _circleIds,
@@ -88,12 +97,27 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   }
 
   /// @inheritdoc IAutomaticSavingCircles
+  function batchExecuteAutomatedClaims(
+    uint256[] calldata _circleIds,
+    address[] calldata _members
+  ) external override nonReentrant onlyAutomationExecutor {
+    if (_circleIds.length != _members.length) revert ArrayLengthMismatch();
+
+    for (uint256 i = 0; i < _circleIds.length; i++) {
+      try this.executeAutomatedClaimTarget(_circleIds[i], _members[i]) {}
+      catch (bytes memory reason) {
+        emit AutomatedClaimFailed(_circleIds[i], _members[i], reason);
+      }
+    }
+  }
+
+  /// @inheritdoc IAutomaticSavingCircles
   function isAutomaticDepositsEnabled(address _member) external view override returns (bool) {
     return automaticDepositsEnabled[_member];
   }
 
   /// @inheritdoc IAutomaticSavingCircles
-  function checker() external view override returns (bool canExec, bytes memory execPayload) {
+  function depositChecker() external view override returns (bool canExec, bytes memory execPayload) {
     uint256[] memory circleIds;
     address[] memory members;
 
@@ -106,6 +130,22 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     }
 
     execPayload = abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedDeposits, (circleIds, members));
+  }
+
+  /// @inheritdoc IAutomaticSavingCircles
+  function claimChecker() external view override returns (bool canExec, bytes memory execPayload) {
+    uint256[] memory circleIds;
+    address[] memory members;
+
+    if (automationExecutor != address(0)) {
+      (circleIds, members) = getEligibleAutomatedClaims();
+      canExec = circleIds.length > 0;
+    } else {
+      circleIds = new uint256[](0);
+      members = new address[](0);
+    }
+
+    execPayload = abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedClaims, (circleIds, members));
   }
 
   /// @inheritdoc IAutomaticSavingCircles
@@ -128,6 +168,29 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     uint256 index = 0;
     for (uint256 circleId = 0; circleId < circleCount; circleId++) {
       index = _populateEligibleAutomatedDepositsForCircle(circleId, circleIds, members, index);
+    }
+  }
+
+  /// @inheritdoc IAutomaticSavingCircles
+  function getEligibleAutomatedClaims()
+    public
+    view
+    override
+    returns (uint256[] memory circleIds, address[] memory members)
+  {
+    uint256 circleCount = SAVING_CIRCLES.nextId();
+    uint256 eligibleCount = 0;
+
+    for (uint256 circleId = 0; circleId < circleCount; circleId++) {
+      eligibleCount += _countEligibleAutomatedClaimsForCircle(circleId);
+    }
+
+    circleIds = new uint256[](eligibleCount);
+    members = new address[](eligibleCount);
+
+    uint256 index = 0;
+    for (uint256 circleId = 0; circleId < circleCount; circleId++) {
+      index = _populateEligibleAutomatedClaimsForCircle(circleId, circleIds, members, index);
     }
   }
 
@@ -164,6 +227,24 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   }
 
   /**
+   * @dev Executes a single automated claim target after re-validating all onchain constraints
+   * @param _circleId Circle to process
+   * @param _member Member to claim for
+   */
+  function _executeAutomatedClaimTarget(uint256 _circleId, address _member) internal {
+    ISavingCircles.Circle memory _circle = SAVING_CIRCLES.getCircle(_circleId);
+    address[] memory members = SAVING_CIRCLES.getCircleMembers(_circleId);
+    (bool isMember, uint256 memberIndex) = _getMemberIndex(members, _member);
+
+    if (!isMember) revert ISavingCircles.NotMember();
+    if (!_isEligibleForAutomatedClaim(_circleId, _circle, _member, memberIndex)) {
+      revert ISavingCircles.NotWithdrawable();
+    }
+
+    SAVING_CIRCLES.withdrawFor(_circleId, _member);
+  }
+
+  /**
    * @dev Returns the current round index for a circle using the live block timestamp
    * @param _circle Circle configuration to evaluate
    * @return The zero-based round index
@@ -177,6 +258,16 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     }
 
     return (block.timestamp - _circle.effectiveCircleStartTime) / _circle.depositInterval;
+  }
+
+  /**
+   * @dev Returns the ending timestamp for a round
+   * @param _circle Circle configuration to evaluate
+   * @param _round Zero-based round index
+   * @return Timestamp when the round's time condition has passed
+   */
+  function _roundEndTime(ISavingCircles.Circle memory _circle, uint256 _round) internal pure returns (uint256) {
+    return _circle.effectiveCircleStartTime + (_circle.depositInterval * (_round + 1));
   }
 
   /**
@@ -222,6 +313,27 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   }
 
   /**
+   * @dev Counts how many members in a circle are currently eligible for automated claim
+   * @param _circleId Circle to inspect
+   * @return eligibleCount Number of eligible claim targets found
+   */
+  function _countEligibleAutomatedClaimsForCircle(uint256 _circleId) internal view returns (uint256 eligibleCount) {
+    try SAVING_CIRCLES.getCircle(_circleId) returns (ISavingCircles.Circle memory _circle) {
+      if (!SAVING_CIRCLES.isActive(_circleId)) return 0;
+      if (SAVING_CIRCLES.isDecommissionable(_circleId)) return 0;
+
+      address[] memory members = SAVING_CIRCLES.getCircleMembers(_circleId);
+      for (uint256 i = 0; i < members.length; i++) {
+        if (_isEligibleForAutomatedClaim(_circleId, _circle, members[i], i)) {
+          eligibleCount++;
+        }
+      }
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
    * @dev Appends the eligible targets for a circle into the output arrays used by the selector
    * @param _circleId Circle to inspect
    * @param _circleIds Output array of eligible circle IDs
@@ -255,6 +367,39 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   }
 
   /**
+   * @dev Appends the eligible claim targets for a circle into the output arrays used by the selector
+   * @param _circleId Circle to inspect
+   * @param _circleIds Output array of eligible circle IDs
+   * @param _members Output array of eligible members
+   * @param _index Current write index in the output arrays
+   * @return nextIndex Updated write index after appending any eligible targets
+   */
+  function _populateEligibleAutomatedClaimsForCircle(
+    uint256 _circleId,
+    uint256[] memory _circleIds,
+    address[] memory _members,
+    uint256 _index
+  ) internal view returns (uint256 nextIndex) {
+    nextIndex = _index;
+
+    try SAVING_CIRCLES.getCircle(_circleId) returns (ISavingCircles.Circle memory _circle) {
+      if (!SAVING_CIRCLES.isActive(_circleId)) return nextIndex;
+      if (SAVING_CIRCLES.isDecommissionable(_circleId)) return nextIndex;
+
+      address[] memory members = SAVING_CIRCLES.getCircleMembers(_circleId);
+      for (uint256 i = 0; i < members.length; i++) {
+        if (!_isEligibleForAutomatedClaim(_circleId, _circle, members[i], i)) continue;
+
+        _circleIds[nextIndex] = _circleId;
+        _members[nextIndex] = members[i];
+        nextIndex++;
+      }
+    } catch {
+      return nextIndex;
+    }
+  }
+
+  /**
    * @dev Returns whether a circle is in a state where automation can process deposits
    * @param _circleId Circle identifier
    * @param _circle Circle configuration to evaluate
@@ -276,6 +421,29 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   }
 
   /**
+   * @dev Returns whether a member currently satisfies the automated claim criteria.
+   *      Gelato should only claim after every member deposited for the member's round and that round's time has passed.
+   * @param _circleId Circle identifier
+   * @param _circle Circle configuration to evaluate
+   * @param _member Member being checked
+   * @param _memberIndex The member's zero-based payout round
+   * @return Whether the member can be included in the claim automation payload
+   */
+  function _isEligibleForAutomatedClaim(
+    uint256 _circleId,
+    ISavingCircles.Circle memory _circle,
+    address _member,
+    uint256 _memberIndex
+  ) internal view returns (bool) {
+    if (!SAVING_CIRCLES.isActive(_circleId)) return false;
+    if (_circle.effectiveCircleStartTime == 0) return false;
+    if (SAVING_CIRCLES.isDecommissionable(_circleId)) return false;
+    if (block.timestamp < _roundEndTime(_circle, _memberIndex)) return false;
+
+    return SAVING_CIRCLES.isMemberWithdrawable(_circleId, _member);
+  }
+
+  /**
    * @dev Looks up whether a member belongs to the supplied balances snapshot and returns their current balance
    * @param _members Snapshot of circle members
    * @param _balances Snapshot of current round balances aligned with `_members`
@@ -291,6 +459,23 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     for (uint256 i = 0; i < _members.length; i++) {
       if (_members[i] != _member) continue;
       return (true, _balances[i]);
+    }
+  }
+
+  /**
+   * @dev Looks up whether a member belongs to the supplied member snapshot and returns their index
+   * @param _members Snapshot of circle members
+   * @param _member Member being searched for
+   * @return isMember Whether the member was found in the snapshot
+   * @return memberIndex The member's zero-based index in the circle
+   */
+  function _getMemberIndex(
+    address[] memory _members,
+    address _member
+  ) internal pure returns (bool isMember, uint256 memberIndex) {
+    for (uint256 i = 0; i < _members.length; i++) {
+      if (_members[i] != _member) continue;
+      return (true, i);
     }
   }
 }

--- a/src/contracts/SavingCircles.sol
+++ b/src/contracts/SavingCircles.sol
@@ -376,11 +376,10 @@ contract SavingCircles is ISavingCircles, ReentrancyGuardUpgradeable, OwnableUpg
   }
 
   /**
-   * @dev Make a withdrawal from a specified circle
-   *      Permissionless: anyone can trigger the payout for the member whose turn it is to withdraw
-   *      A withdrawal must be made by a member of the circle, even if it is for another member.
+   * @dev Make a withdrawal from a specified circle.
+   *      Anyone can trigger the payout for a valid member whose turn is withdrawable.
    */
-  function _withdraw(uint256 _id, address _member) internal onlyMember(_id, msg.sender) {
+  function _withdraw(uint256 _id, address _member) internal onlyMember(_id, _member) {
     Circle storage _circle = circles[_id];
 
     if (!_claimable(_id, _member)) revert NotWithdrawable();

--- a/src/interfaces/IAutomaticSavingCircles.sol
+++ b/src/interfaces/IAutomaticSavingCircles.sol
@@ -30,6 +30,14 @@ interface IAutomaticSavingCircles {
   event AutomatedDepositFailed(uint256 indexed circleId, address indexed member, bytes reason);
 
   /**
+   * @notice Emitted when an automated claim target fails during batch execution
+   * @param circleId The circle that failed
+   * @param member The member that failed
+   * @param reason The raw revert data returned by the failed execution
+   */
+  event AutomatedClaimFailed(uint256 indexed circleId, address indexed member, bytes reason);
+
+  /**
    * @notice Thrown when a non-Gelato caller attempts an automated execution
    */
   error OnlyAutomationExecutor();
@@ -74,6 +82,13 @@ interface IAutomaticSavingCircles {
   function batchExecuteAutomatedDeposits(uint256[] calldata circleIds, address[] calldata members) external;
 
   /**
+   * @notice Execute automated claims for precomputed targets
+   * @param circleIds Circle IDs to process
+   * @param members Members to process for each circle ID
+   */
+  function batchExecuteAutomatedClaims(uint256[] calldata circleIds, address[] calldata members) external;
+
+  /**
    * @notice The configured Gelato dedicated msg.sender
    * @return The automation executor address
    */
@@ -94,9 +109,23 @@ interface IAutomaticSavingCircles {
   function getEligibleAutomatedDeposits() external view returns (uint256[] memory circleIds, address[] memory members);
 
   /**
+   * @notice Return every member/circle pair currently eligible for automated claim
+   * @return circleIds Circle IDs with pending automated claims
+   * @return members Members eligible to claim in each circle
+   */
+  function getEligibleAutomatedClaims() external view returns (uint256[] memory circleIds, address[] memory members);
+
+  /**
    * @notice Gelato resolver-style checker for automatic deposits across every circle
    * @return canExec Whether Gelato should execute the sweep
    * @return execPayload Encoded calldata for the automated deposit execution
    */
-  function checker() external view returns (bool canExec, bytes memory execPayload);
+  function depositChecker() external view returns (bool canExec, bytes memory execPayload);
+
+  /**
+   * @notice Gelato resolver-style checker for automatic claims across every circle
+   * @return canExec Whether Gelato should execute the claims
+   * @return execPayload Encoded calldata for the automated claim execution
+   */
+  function claimChecker() external view returns (bool canExec, bytes memory execPayload);
 }

--- a/src/interfaces/IAutomaticSavingCircles.sol
+++ b/src/interfaces/IAutomaticSavingCircles.sol
@@ -124,7 +124,7 @@ interface IAutomaticSavingCircles {
 
   /**
    * @notice Gelato resolver-style checker for automatic claims across every circle
-   * @return canExec Whether Gelato should execute the claims
+   * @return canExec Whether Gelato can execute the claims
    * @return execPayload Encoded calldata for the automated claim execution
    */
   function claimChecker() external view returns (bool canExec, bytes memory execPayload);

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -110,7 +110,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     _fundEnableAndApprove(bob, totalRequiredPerMember);
     _fundEnableAndApprove(carol, totalRequiredPerMember);
 
-    (bool canExec, bytes memory execPayload) = automaticSavingCircles.checker();
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
     assertTrue(canExec);
 
     vm.prank(gelatoExecutor);
@@ -159,7 +159,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     vm.prank(carol);
     token.approve(address(automaticSavingCircles), DEPOSIT_AMOUNT);
 
-    (bool canExec, bytes memory execPayload) = automaticSavingCircles.checker();
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
     assertTrue(canExec);
 
     vm.prank(gelatoExecutor);
@@ -265,11 +265,17 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     automaticSavingCircles.executeAutomatedDepositTarget(baseCircleId, alice);
   }
 
+  function test_ExecuteAutomatedClaimTarget_WhenCallerIsNotSelf() external {
+    vm.prank(alice);
+    vm.expectRevert(AutomaticSavingCircles.OnlySelf.selector);
+    automaticSavingCircles.executeAutomatedClaimTarget(baseCircleId, alice);
+  }
+
   function test_Checker_ReturnsTrueAndExecPayloadWhenAnyEligibleMemberExists() external {
     _fundEnableAndApprove(alice, DEPOSIT_AMOUNT);
     (uint256[] memory circleIds, address[] memory targetMembers) = automaticSavingCircles.getEligibleAutomatedDeposits();
 
-    (bool canExec, bytes memory execPayload) = automaticSavingCircles.checker();
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
 
     assertTrue(canExec);
     assertEq(
@@ -283,14 +289,14 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     vm.prank(owner);
     automaticSavingCircles.setAutomationExecutor(address(0));
 
-    (bool canExec, bytes memory execPayload) = automaticSavingCircles.checker();
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
 
     assertFalse(canExec);
     assertEq(execPayload, _emptyBatchPayload());
   }
 
   function test_Checker_ReturnsFalseWhenNoEligibleMembersExist() external view {
-    (bool canExec, bytes memory execPayload) = automaticSavingCircles.checker();
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
 
     assertFalse(canExec);
     assertEq(execPayload, _emptyBatchPayload());
@@ -308,7 +314,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     vm.prank(alice);
     token.approve(address(automaticSavingCircles), DEPOSIT_AMOUNT * 2);
 
-    (bool canExec, bytes memory execPayload) = automaticSavingCircles.checker();
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
 
     assertFalse(canExec);
     assertEq(execPayload, _emptyBatchPayload());
@@ -329,6 +335,103 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     assertEq(targetMembers.length, 1);
     assertEq(circleIds[0], baseCircleId);
     assertEq(targetMembers[0], alice);
+  }
+
+  function test_GetEligibleAutomatedClaims_ReturnsOnlyWhenAllMembersDepositedAndRoundTimePassed() external {
+    _depositRound(baseCircleId);
+
+    (uint256[] memory circleIdsBefore, address[] memory targetMembersBefore) =
+      automaticSavingCircles.getEligibleAutomatedClaims();
+    assertEq(circleIdsBefore.length, 0);
+    assertEq(targetMembersBefore.length, 0);
+
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
+
+    (uint256[] memory circleIdsAfter, address[] memory targetMembersAfter) =
+      automaticSavingCircles.getEligibleAutomatedClaims();
+
+    assertEq(circleIdsAfter.length, 1);
+    assertEq(targetMembersAfter.length, 1);
+    assertEq(circleIdsAfter[0], baseCircleId);
+    assertEq(targetMembersAfter[0], alice);
+  }
+
+  function test_GetEligibleAutomatedClaims_ReturnsFalseWhenRoundTimePassedButDepositsIncomplete() external {
+    token.mint(alice, DEPOSIT_AMOUNT);
+    vm.startPrank(alice);
+    token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+    savingCircles.deposit(baseCircleId, DEPOSIT_AMOUNT);
+    vm.stopPrank();
+
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
+
+    (uint256[] memory circleIds, address[] memory targetMembers) = automaticSavingCircles.getEligibleAutomatedClaims();
+
+    assertEq(circleIds.length, 0);
+    assertEq(targetMembers.length, 0);
+  }
+
+  function test_ClaimCheckerPayload_ClaimsForEligibleMembersAcrossAllCircles() external {
+    uint256 secondCircleId = _createStartedCircle();
+    _depositRound(baseCircleId);
+    _depositRound(secondCircleId);
+
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
+
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.claimChecker();
+    assertTrue(canExec);
+
+    vm.prank(gelatoExecutor);
+    (bool success,) = address(automaticSavingCircles).call(execPayload);
+    assertTrue(success);
+
+    assertTrue(savingCircles.hasClaimed(baseCircleId, alice));
+    assertTrue(savingCircles.hasClaimed(secondCircleId, alice));
+    assertEq(token.balanceOf(alice), DEPOSIT_AMOUNT * members.length * 2);
+  }
+
+  function test_ClaimChecker_ReturnsFalseWhenAutomationExecutorUnset() external {
+    _depositRound(baseCircleId);
+
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
+
+    vm.prank(owner);
+    automaticSavingCircles.setAutomationExecutor(address(0));
+
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.claimChecker();
+
+    assertFalse(canExec);
+    assertEq(execPayload, _emptyClaimBatchPayload());
+  }
+
+  function test_ClaimChecker_ReturnsFalseWhenNoEligibleClaimsExist() external view {
+    (bool canExec, bytes memory execPayload) = automaticSavingCircles.claimChecker();
+
+    assertFalse(canExec);
+    assertEq(execPayload, _emptyClaimBatchPayload());
+  }
+
+  function test_BatchExecuteAutomatedClaims_WhenCallerIsNotAutomationExecutor() external {
+    uint256[] memory circleIds = new uint256[](0);
+    address[] memory targetMembers = new address[](0);
+
+    vm.prank(owner);
+    vm.expectRevert(abi.encodeWithSelector(IAutomaticSavingCircles.OnlyAutomationExecutor.selector));
+    automaticSavingCircles.batchExecuteAutomatedClaims(circleIds, targetMembers);
+  }
+
+  function test_BatchExecuteAutomatedClaims_RevertsOnMismatchedArrays() external {
+    uint256[] memory circleIds = new uint256[](1);
+    address[] memory targetMembers = new address[](0);
+    circleIds[0] = baseCircleId;
+
+    vm.prank(gelatoExecutor);
+    vm.expectRevert(abi.encodeWithSelector(IAutomaticSavingCircles.ArrayLengthMismatch.selector));
+    automaticSavingCircles.batchExecuteAutomatedClaims(circleIds, targetMembers);
   }
 
   function _fundEnableAndApprove(address _member, uint256 _amount) internal {
@@ -358,6 +461,20 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
 
   function _emptyBatchPayload() internal pure returns (bytes memory) {
     return abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedDeposits, (new uint256[](0), new address[](0)));
+  }
+
+  function _emptyClaimBatchPayload() internal pure returns (bytes memory) {
+    return abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedClaims, (new uint256[](0), new address[](0)));
+  }
+
+  function _depositRound(uint256 _circleId) internal {
+    for (uint256 i = 0; i < members.length; i++) {
+      token.mint(members[i], DEPOSIT_AMOUNT);
+      vm.startPrank(members[i]);
+      token.approve(address(savingCircles), DEPOSIT_AMOUNT);
+      savingCircles.deposit(_circleId, DEPOSIT_AMOUNT);
+      vm.stopPrank();
+    }
   }
 
   function _depositBaseCircleForAlice() internal {

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -428,6 +428,31 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     automaticSavingCircles.batchExecuteAutomatedClaims(circleIds, targetMembers);
   }
 
+  function test_BatchExecuteAutomatedClaims_ContinuesWhenOneTargetFails() external {
+    _depositRound(baseCircleId);
+
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
+
+    uint256[] memory circleIds = new uint256[](2);
+    address[] memory targetMembers = new address[](2);
+    circleIds[0] = baseCircleId;
+    circleIds[1] = baseCircleId;
+    targetMembers[0] = bob;
+    targetMembers[1] = alice;
+
+    vm.prank(gelatoExecutor);
+    vm.expectEmit(true, true, false, true, address(automaticSavingCircles));
+    emit IAutomaticSavingCircles.AutomatedClaimFailed(
+      baseCircleId, bob, abi.encodeWithSelector(ISavingCircles.NotWithdrawable.selector)
+    );
+    automaticSavingCircles.batchExecuteAutomatedClaims(circleIds, targetMembers);
+
+    assertFalse(savingCircles.hasClaimed(baseCircleId, bob));
+    assertTrue(savingCircles.hasClaimed(baseCircleId, alice));
+    assertEq(token.balanceOf(alice), DEPOSIT_AMOUNT * members.length);
+  }
+
   function test_BatchExecuteAutomatedClaims_RevertsOnMismatchedArrays() external {
     uint256[] memory circleIds = new uint256[](1);
     address[] memory targetMembers = new address[](0);

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -292,14 +292,14 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
 
     assertFalse(canExec);
-    assertEq(execPayload, _emptyBatchPayload());
+    assertEq(execPayload, bytes(''));
   }
 
   function test_Checker_ReturnsFalseWhenNoEligibleMembersExist() external view {
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
 
     assertFalse(canExec);
-    assertEq(execPayload, _emptyBatchPayload());
+    assertEq(execPayload, bytes(''));
   }
 
   function test_Checker_ReturnsFalseWhenOnlyUnstartedCirclesHaveEligibleMembers() external {
@@ -317,7 +317,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
 
     assertFalse(canExec);
-    assertEq(execPayload, _emptyBatchPayload());
+    assertEq(execPayload, bytes(''));
   }
 
   function test_GetEligibleAutomatedDeposits_SkipsDecommissionedCircles() external {
@@ -409,14 +409,14 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.claimChecker();
 
     assertFalse(canExec);
-    assertEq(execPayload, _emptyClaimBatchPayload());
+    assertEq(execPayload, bytes(''));
   }
 
   function test_ClaimChecker_ReturnsFalseWhenNoEligibleClaimsExist() external view {
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.claimChecker();
 
     assertFalse(canExec);
-    assertEq(execPayload, _emptyClaimBatchPayload());
+    assertEq(execPayload, bytes(''));
   }
 
   function test_BatchExecuteAutomatedClaims_WhenCallerIsNotAutomationExecutor() external {
@@ -486,14 +486,6 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
   function _createUnstartedCircle() internal returns (uint256) {
     ISavingCircles.Circle memory circle = _defaultCircle(alice, DEPOSIT_AMOUNT, DEPOSIT_INTERVAL, address(token));
     return _createCircle(savingCircles, circle, members, _alicePrivateKey);
-  }
-
-  function _emptyBatchPayload() internal pure returns (bytes memory) {
-    return abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedDeposits, (new uint256[](0), new address[](0)));
-  }
-
-  function _emptyClaimBatchPayload() internal pure returns (bytes memory) {
-    return abi.encodeCall(IAutomaticSavingCircles.batchExecuteAutomatedClaims, (new uint256[](0), new address[](0)));
   }
 
   function _depositRound(uint256 _circleId) internal {

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -384,6 +384,10 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.claimChecker();
     assertTrue(canExec);
 
+    assertFalse(savingCircles.hasClaimed(baseCircleId, alice));
+    assertFalse(savingCircles.hasClaimed(secondCircleId, alice));
+    assertEq(token.balanceOf(alice), 0);
+
     vm.prank(gelatoExecutor);
     (bool success,) = address(automaticSavingCircles).call(execPayload);
     assertTrue(success);

--- a/test/unit/SavingCirclesUnit.t.sol
+++ b/test/unit/SavingCirclesUnit.t.sol
@@ -1068,8 +1068,8 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     vm.stopPrank();
   }
 
-  function test_WithdrawForNonMember() external {
-    // Test withdrawFor when caller is not a member
+  function test_WithdrawForWhenCallerIsNotMember() external {
+    // Test permissionless withdrawFor when caller is not a member
     // Complete deposits first
     vm.warp(baseCircleStart);
     for (uint256 i = 0; i < members.length; i++) {
@@ -1084,8 +1084,16 @@ contract SavingCirclesUnit is SavingCirclesTestBase {
     vm.warp(block.timestamp + DEPOSIT_INTERVAL);
 
     vm.prank(STRANGER); // Non-member trying to call withdrawFor
-    vm.expectRevert(ISavingCircles.NotMember.selector);
     savingCircles.withdrawFor(baseCircleId, alice);
+
+    assertTrue(savingCircles.hasClaimed(baseCircleId, alice));
+    assertEq(token.balanceOf(alice), DEPOSIT_AMOUNT * members.length);
+  }
+
+  function test_WithdrawForWhenTargetIsNotMember() external {
+    vm.prank(STRANGER);
+    vm.expectRevert(ISavingCircles.NotMember.selector);
+    savingCircles.withdrawFor(baseCircleId, STRANGER);
   }
 
   // ============ Edge Case Tests for Decommission ============


### PR DESCRIPTION
## Summary

This PR adds Gelato-powered automatic claims to the existing `AutomaticSavingCircles` automation extension.

Gelato can now resolve and execute claimable payouts automatically once both required conditions are true:
- all members have deposited for the payout round,
- the payout round’s time window has passed.

## What Changed

Added a new automatic claim flow:
- `claimChecker()` scans all circles and returns executable calldata when any member is eligible to claim.
- `getEligibleAutomatedClaims()` returns all eligible `(circleId, member)` claim targets.
- `batchExecuteAutomatedClaims(...)` executes claim targets through Gelato’s configured executor.
- `executeAutomatedClaimTarget(...)` is used internally so failed targets do not block the full batch with the try/catch pattern.
- `AutomatedClaimFailed(...)` is emitted when an individual claim target fails during batch execution.

Claim eligibility requires:
- the circle is active,
- the circle is not decommissionable,
- the member’s payout round time has passed,
- `SavingCircles.isMemberWithdrawable(circleId, member)` returns true.

This means Gelato only claims when deposits are complete and the time condition is satisfied.

## SavingCircles Change

`withdrawFor(...)` is now truly permissionless for valid claim recipients. The caller no longer needs to be a circle member; instead, the target member must be a valid member and must be withdrawable.

This is required because the automation contract is not a member of each circle, but it needs to trigger claims on behalf of eligible members. The payout safety checks still remain in place through `_claimable(...)`.

## Tests

Added coverage for:
- claim targets are not returned before the round time has passed,
- claim targets are not returned when deposits are incomplete,
- `claimChecker()` returns the correct batch execution payload,
- automatic claims execute across multiple circles,
- only the configured Gelato executor can run claim batches,
- mismatched claim batch arrays revert,
- non-member callers can trigger `withdrawFor(...)` for valid recipients,
- invalid claim recipients still revert.

Validation:
- `forge test`
Full suite passes: 156 tests.