### PR TITLE
fix: avoid nested ProxyAdmin on deploy

### DIFF
--- a/script/Common.sol
+++ b/script/Common.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
 import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import {Script} from 'forge-std/Script.sol';
 import {console2} from 'forge-std/console2.sol';
@@ -23,23 +22,17 @@ contract Common is Script {
     return new SavingCircles();
   }
 
-  function _deployProxyAdmin(address _admin) internal returns (ProxyAdmin) {
-    return new ProxyAdmin(_admin);
-  }
-
   function _deployTransparentProxy(
     address _implementation,
-    address _proxyAdmin,
+    address _initialAdminOwner,
     bytes memory _initData
   ) internal returns (TransparentUpgradeableProxy) {
-    return new TransparentUpgradeableProxy(_implementation, _proxyAdmin, _initData);
+    return new TransparentUpgradeableProxy(_implementation, _initialAdminOwner, _initData);
   }
 
   function _deployContracts(address _admin) internal returns (TransparentUpgradeableProxy) {
     TransparentUpgradeableProxy proxy = _deployTransparentProxy(
-      address(_deploySavingCircles()),
-      address(_deployProxyAdmin(_admin)),
-      abi.encodeWithSelector(SavingCircles.initialize.selector, _admin)
+      address(_deploySavingCircles()), _admin, abi.encodeWithSelector(SavingCircles.initialize.selector, _admin)
     );
 
     // Deploy auxiliary contracts that reference the SavingCircles proxy


### PR DESCRIPTION
## Problem

The deploy script in [script/Common.sol](script/Common.sol) created a nested `ProxyAdmin` chain: the proxy's internally-created `ProxyAdmin` ended up owned by *another* externally-deployed `ProxyAdmin`, which was in turn owned by the deployer EOA. This made upgrade authority easy to misconfigure and operationally unsafe.

## Root cause

In OpenZeppelin v5, `TransparentUpgradeableProxy`'s constructor:

```solidity
constructor(address _logic, address initialOwner, bytes memory _data)
```

creates its **own** `ProxyAdmin` internally and uses the second argument as that admin's **initial owner** — not as the admin itself. The previous deploy code was passing `address(new ProxyAdmin(_admin))` there, which is what produced the nested chain.

## Fix

Pass `_admin` (the EOA) directly as the second argument. The proxy's internally-created `ProxyAdmin` is then owned by the EOA, with no intermediate contract.

Diff is 3 insertions / 10 deletions in [script/Common.sol](script/Common.sol).

## Scope

This is intentionally minimal — only the fix for the nested `ProxyAdmin` bug. The broader guardrails and validation scripts from the closed [#119](https://github.com/BreadchainCoop/saving-circles/pull/119) are not included here.


## Validation

- `forge build` passes
- `forge test` — all 147 tests pass