### PR TITLE
Add per-circle opt-in for automatic claims

### DIFF
--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -23,8 +23,8 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   /// @notice Dedicated Gelato msg.sender allowed to execute automated batches
   address public automationExecutor;
 
-  /// @notice Mapping to track which members have enabled automatic deposits
-  mapping(address member => bool enabled) public automaticDepositsEnabled;
+  /// @notice Mapping to track which members have enabled automatic deposits in each circle
+  mapping(uint256 circleId => mapping(address member => bool enabled)) public automaticDepositsEnabled;
 
   /// @notice Mapping to track which members have enabled automatic claims in each circle
   mapping(uint256 circleId => mapping(address member => bool enabled)) public automaticClaimsEnabled;
@@ -54,9 +54,9 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   }
 
   /// @inheritdoc IAutomaticSavingCircles
-  function setAutomaticDepositsEnabled(bool _enabled) external override {
-    automaticDepositsEnabled[msg.sender] = _enabled;
-    emit AutomaticDepositsToggled(msg.sender, _enabled);
+  function setAutomaticDepositsEnabled(uint256 _circleId, bool _enabled) external override {
+    automaticDepositsEnabled[_circleId][msg.sender] = _enabled;
+    emit AutomaticDepositsToggled(_circleId, msg.sender, _enabled);
   }
 
   /// @inheritdoc IAutomaticSavingCircles
@@ -121,8 +121,8 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   }
 
   /// @inheritdoc IAutomaticSavingCircles
-  function isAutomaticDepositsEnabled(address _member) external view override returns (bool) {
-    return automaticDepositsEnabled[_member];
+  function isAutomaticDepositsEnabled(uint256 _circleId, address _member) external view override returns (bool) {
+    return automaticDepositsEnabled[_circleId][_member];
   }
 
   /// @inheritdoc IAutomaticSavingCircles
@@ -221,7 +221,7 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
 
     (bool isMember, uint256 currentBalance) = _getMemberBalance(members, balances, _member);
     if (!isMember) revert ISavingCircles.NotMember();
-    if (!automaticDepositsEnabled[_member]) revert AutomaticDepositsNotEnabled();
+    if (!automaticDepositsEnabled[_circleId][_member]) revert AutomaticDepositsNotEnabled();
     if (currentBalance >= _circle.depositAmount) revert ISavingCircles.AlreadyDeposited();
 
     uint256 requiredAmount = _circle.depositAmount - currentBalance;
@@ -284,17 +284,19 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
 
   /**
    * @dev Returns whether a member currently satisfies the offchain selection criteria for automated deposit
+   * @param _circleId Circle to inspect
    * @param _circle Circle configuration to evaluate
    * @param _member Member being checked
    * @param _currentBalance Amount already deposited by the member in the active round
    * @return Whether the member can be included in the automation payload
    */
   function _isEligibleForAutomatedDeposit(
+    uint256 _circleId,
     ISavingCircles.Circle memory _circle,
     address _member,
     uint256 _currentBalance
   ) internal view returns (bool) {
-    if (!automaticDepositsEnabled[_member]) return false;
+    if (!automaticDepositsEnabled[_circleId][_member]) return false;
     if (_currentBalance >= _circle.depositAmount) return false;
 
     uint256 requiredAmount = _circle.depositAmount - _currentBalance;
@@ -315,7 +317,7 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
       if (!_isCircleEligibleForAutomation(_circleId, _circle, members.length)) return 0;
 
       for (uint256 i = 0; i < members.length; i++) {
-        if (_isEligibleForAutomatedDeposit(_circle, members[i], balances[i])) {
+        if (_isEligibleForAutomatedDeposit(_circleId, _circle, members[i], balances[i])) {
           eligibleCount++;
         }
       }
@@ -367,7 +369,7 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
       if (!_isCircleEligibleForAutomation(_circleId, _circle, members.length)) return nextIndex;
 
       for (uint256 i = 0; i < members.length; i++) {
-        if (!_isEligibleForAutomatedDeposit(_circle, members[i], balances[i])) continue;
+        if (!_isEligibleForAutomatedDeposit(_circleId, _circle, members[i], balances[i])) continue;
 
         _circleIds[nextIndex] = _circleId;
         _members[nextIndex] = members[i];

--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -246,6 +246,8 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     (bool isMember, uint256 memberIndex) = _getMemberIndex(members, _member);
 
     if (!isMember) revert ISavingCircles.NotMember();
+    // Re-checked here so executor-supplied targets get a specific AutomaticClaimsNotEnabled error
+    // instead of the generic NotWithdrawable returned by _isEligibleForAutomatedClaim.
     if (!automaticClaimsEnabled[_circleId][_member]) revert AutomaticClaimsNotEnabled();
     if (!_isEligibleForAutomatedClaim(_circleId, _circle, _member, memberIndex)) {
       revert ISavingCircles.NotWithdrawable();

--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -20,7 +20,7 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   /// @notice The main SavingCircles contract
   ISavingCircles public immutable SAVING_CIRCLES;
 
-  /// @notice Dedicated Gelato msg.sender allowed to execute automated batches
+  /// @notice Dedicated Gelato `msg.sender` allowed to execute automated batches
   address public automationExecutor;
 
   /// @notice Mapping to track which members have enabled automatic deposits in each circle

--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -242,13 +242,13 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
    */
   function _executeAutomatedClaimTarget(uint256 _circleId, address _member) internal {
     ISavingCircles.Circle memory _circle = SAVING_CIRCLES.getCircle(_circleId);
+    // Check opt-in before fetching members while retaining the specific error for an invalid circle.
+    if (!automaticClaimsEnabled[_circleId][_member]) revert AutomaticClaimsDisabled();
+
     address[] memory members = SAVING_CIRCLES.getCircleMembers(_circleId);
     (bool isMember, uint256 memberIndex) = _getMemberIndex(members, _member);
 
     if (!isMember) revert ISavingCircles.NotMember();
-    // Re-checked here so executor-supplied targets get a specific AutomaticClaimsDisabled error
-    // instead of the generic NotWithdrawable returned by _isEligibleForAutomatedClaim.
-    if (!automaticClaimsEnabled[_circleId][_member]) revert AutomaticClaimsDisabled();
     if (!_isEligibleForAutomatedClaim(_circleId, _circle, _member, memberIndex)) {
       revert ISavingCircles.NotWithdrawable();
     }

--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -246,9 +246,9 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     (bool isMember, uint256 memberIndex) = _getMemberIndex(members, _member);
 
     if (!isMember) revert ISavingCircles.NotMember();
-    // Re-checked here so executor-supplied targets get a specific AutomaticClaimsNotEnabled error
+    // Re-checked here so executor-supplied targets get a specific AutomaticClaimsDisabled error
     // instead of the generic NotWithdrawable returned by _isEligibleForAutomatedClaim.
-    if (!automaticClaimsEnabled[_circleId][_member]) revert AutomaticClaimsNotEnabled();
+    if (!automaticClaimsEnabled[_circleId][_member]) revert AutomaticClaimsDisabled();
     if (!_isEligibleForAutomatedClaim(_circleId, _circle, _member, memberIndex)) {
       revert ISavingCircles.NotWithdrawable();
     }

--- a/src/contracts/AutomaticSavingCircles.sol
+++ b/src/contracts/AutomaticSavingCircles.sol
@@ -13,18 +13,21 @@ using SafeERC20 for IERC20;
 
 /**
  * @title AutomaticSavingCircles
- * @notice Extension contract for automatic deposits in SavingCircles
- * @dev This contract exposes Gelato-friendly target selection and batch execution for automated deposits
+ * @notice Extension contract for automated deposits and claims in SavingCircles
+ * @dev This contract exposes Gelato-friendly target selection and batch execution for automated actions
  */
 contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyGuard {
   /// @notice The main SavingCircles contract
   ISavingCircles public immutable SAVING_CIRCLES;
 
-  /// @notice Dedicated Gelato msg.sender allowed to execute automated deposit batches
+  /// @notice Dedicated Gelato msg.sender allowed to execute automated batches
   address public automationExecutor;
 
   /// @notice Mapping to track which members have enabled automatic deposits
   mapping(address member => bool enabled) public automaticDepositsEnabled;
+
+  /// @notice Mapping to track which members have enabled automatic claims in each circle
+  mapping(uint256 circleId => mapping(address member => bool enabled)) public automaticClaimsEnabled;
 
   /// @notice Thrown when an internal execution trampoline is called externally
   error OnlySelf();
@@ -54,6 +57,12 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   function setAutomaticDepositsEnabled(bool _enabled) external override {
     automaticDepositsEnabled[msg.sender] = _enabled;
     emit AutomaticDepositsToggled(msg.sender, _enabled);
+  }
+
+  /// @inheritdoc IAutomaticSavingCircles
+  function setAutomaticClaimsEnabled(uint256 _circleId, bool _enabled) external override {
+    automaticClaimsEnabled[_circleId][msg.sender] = _enabled;
+    emit AutomaticClaimsToggled(_circleId, msg.sender, _enabled);
   }
 
   /// @inheritdoc IAutomaticSavingCircles
@@ -114,6 +123,11 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
   /// @inheritdoc IAutomaticSavingCircles
   function isAutomaticDepositsEnabled(address _member) external view override returns (bool) {
     return automaticDepositsEnabled[_member];
+  }
+
+  /// @inheritdoc IAutomaticSavingCircles
+  function isAutomaticClaimsEnabled(uint256 _circleId, address _member) external view override returns (bool) {
+    return automaticClaimsEnabled[_circleId][_member];
   }
 
   /// @inheritdoc IAutomaticSavingCircles
@@ -232,6 +246,7 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     (bool isMember, uint256 memberIndex) = _getMemberIndex(members, _member);
 
     if (!isMember) revert ISavingCircles.NotMember();
+    if (!automaticClaimsEnabled[_circleId][_member]) revert AutomaticClaimsNotEnabled();
     if (!_isEligibleForAutomatedClaim(_circleId, _circle, _member, memberIndex)) {
       revert ISavingCircles.NotWithdrawable();
     }
@@ -430,6 +445,7 @@ contract AutomaticSavingCircles is IAutomaticSavingCircles, Ownable, ReentrancyG
     address _member,
     uint256 _memberIndex
   ) internal view returns (bool) {
+    if (!automaticClaimsEnabled[_circleId][_member]) return false;
     if (!SAVING_CIRCLES.isActive(_circleId)) return false;
     if (_circle.effectiveCircleStartTime == 0) return false;
     if (SAVING_CIRCLES.isDecommissionable(_circleId)) return false;

--- a/src/interfaces/IAutomaticSavingCircles.sol
+++ b/src/interfaces/IAutomaticSavingCircles.sol
@@ -82,7 +82,7 @@ interface IAutomaticSavingCircles {
   function setAutomaticDepositsEnabled(bool enabled) external;
 
   /**
-   * @notice Enable or disable automatic claims for the caller in one circle
+   * @notice Enable or disable automatic claims for the caller for one circle
    * @param circleId The circle to configure
    * @param enabled Whether to enable automatic claims
    */

--- a/src/interfaces/IAutomaticSavingCircles.sol
+++ b/src/interfaces/IAutomaticSavingCircles.sol
@@ -58,7 +58,7 @@ interface IAutomaticSavingCircles {
   /**
    * @notice Thrown when automatic claims have not been enabled for a member in a circle
    */
-  error AutomaticClaimsNotEnabled();
+  error AutomaticClaimsDisabled();
 
   /**
    * @notice Thrown when batch execution inputs have mismatched array lengths

--- a/src/interfaces/IAutomaticSavingCircles.sol
+++ b/src/interfaces/IAutomaticSavingCircles.sol
@@ -8,11 +8,12 @@ pragma solidity 0.8.28;
  */
 interface IAutomaticSavingCircles {
   /**
-   * @notice Emitted when a member enables or disables automatic deposits
+   * @notice Emitted when a member enables or disables automatic deposits for a circle
+   * @param circleId The circle configured by the member
    * @param member The address of the member
    * @param enabled Whether automatic deposits are enabled
    */
-  event AutomaticDepositsToggled(address indexed member, bool indexed enabled);
+  event AutomaticDepositsToggled(uint256 indexed circleId, address indexed member, bool indexed enabled);
 
   /**
    * @notice Emitted when a member enables or disables automatic claims for a circle
@@ -51,7 +52,7 @@ interface IAutomaticSavingCircles {
   error OnlyAutomationExecutor();
 
   /**
-   * @notice Thrown when automatic deposits have not been enabled for a member
+   * @notice Thrown when automatic deposits have not been enabled for a member in a circle
    */
   error AutomaticDepositsNotEnabled();
 
@@ -76,10 +77,11 @@ interface IAutomaticSavingCircles {
   error InsufficientBalance();
 
   /**
-   * @notice Enable or disable automatic deposits for the caller across every circle they belong to
+   * @notice Enable or disable automatic deposits for the caller for one circle
+   * @param circleId The circle to configure
    * @param enabled Whether to enable automatic deposits
    */
-  function setAutomaticDepositsEnabled(bool enabled) external;
+  function setAutomaticDepositsEnabled(uint256 circleId, bool enabled) external;
 
   /**
    * @notice Enable or disable automatic claims for the caller for one circle
@@ -115,11 +117,12 @@ interface IAutomaticSavingCircles {
   function automationExecutor() external view returns (address);
 
   /**
-   * @notice Check if automatic deposits are enabled for a member
+   * @notice Check if automatic deposits are enabled for a member in a circle
+   * @param circleId The circle to check
    * @param member The address to check
    * @return Whether automatic deposits are enabled
    */
-  function isAutomaticDepositsEnabled(address member) external view returns (bool);
+  function isAutomaticDepositsEnabled(uint256 circleId, address member) external view returns (bool);
 
   /**
    * @notice Check if automatic claims are enabled for a member in a circle

--- a/src/interfaces/IAutomaticSavingCircles.sol
+++ b/src/interfaces/IAutomaticSavingCircles.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 /**
  * @title IAutomaticSavingCircles
- * @notice Interface for the SavingCircles automatic deposits extension contract
- * @dev This extension is intended for Gelato-driven automated deposits only
+ * @notice Interface for the SavingCircles automation extension contract
+ * @dev This extension is intended for Gelato-driven automated deposits and claims
  */
 interface IAutomaticSavingCircles {
   /**
@@ -13,6 +13,14 @@ interface IAutomaticSavingCircles {
    * @param enabled Whether automatic deposits are enabled
    */
   event AutomaticDepositsToggled(address indexed member, bool indexed enabled);
+
+  /**
+   * @notice Emitted when a member enables or disables automatic claims for a circle
+   * @param circleId The circle configured by the member
+   * @param member The address of the member
+   * @param enabled Whether automatic claims are enabled
+   */
+  event AutomaticClaimsToggled(uint256 indexed circleId, address indexed member, bool indexed enabled);
 
   /**
    * @notice Emitted when the Gelato automation executor is updated
@@ -48,6 +56,11 @@ interface IAutomaticSavingCircles {
   error AutomaticDepositsNotEnabled();
 
   /**
+   * @notice Thrown when automatic claims have not been enabled for a member in a circle
+   */
+  error AutomaticClaimsNotEnabled();
+
+  /**
    * @notice Thrown when batch execution inputs have mismatched array lengths
    */
   error ArrayLengthMismatch();
@@ -69,7 +82,14 @@ interface IAutomaticSavingCircles {
   function setAutomaticDepositsEnabled(bool enabled) external;
 
   /**
-   * @notice Configure the Gelato dedicated msg.sender allowed to execute automated deposits
+   * @notice Enable or disable automatic claims for the caller in one circle
+   * @param circleId The circle to configure
+   * @param enabled Whether to enable automatic claims
+   */
+  function setAutomaticClaimsEnabled(uint256 circleId, bool enabled) external;
+
+  /**
+   * @notice Configure the Gelato dedicated msg.sender allowed to execute automated batches
    * @param automationExecutor The dedicated Gelato executor address for this network
    */
   function setAutomationExecutor(address automationExecutor) external;
@@ -100,6 +120,14 @@ interface IAutomaticSavingCircles {
    * @return Whether automatic deposits are enabled
    */
   function isAutomaticDepositsEnabled(address member) external view returns (bool);
+
+  /**
+   * @notice Check if automatic claims are enabled for a member in a circle
+   * @param circleId The circle to check
+   * @param member The address to check
+   * @return Whether automatic claims are enabled
+   */
+  function isAutomaticClaimsEnabled(uint256 circleId, address member) external view returns (bool);
 
   /**
    * @notice Return every member/circle pair currently eligible for automated deposit

--- a/src/interfaces/IAutomaticSavingCircles.sol
+++ b/src/interfaces/IAutomaticSavingCircles.sol
@@ -91,7 +91,7 @@ interface IAutomaticSavingCircles {
   function setAutomaticClaimsEnabled(uint256 circleId, bool enabled) external;
 
   /**
-   * @notice Configure the Gelato dedicated msg.sender allowed to execute automated batches
+   * @notice Configure the Gelato dedicated `msg.sender` allowed to execute automated batches
    * @param automationExecutor The dedicated Gelato executor address for this network
    */
   function setAutomationExecutor(address automationExecutor) external;
@@ -111,7 +111,7 @@ interface IAutomaticSavingCircles {
   function batchExecuteAutomatedClaims(uint256[] calldata circleIds, address[] calldata members) external;
 
   /**
-   * @notice The configured Gelato dedicated msg.sender
+   * @notice The configured Gelato dedicated `msg.sender`
    * @return The automation executor address
    */
   function automationExecutor() external view returns (address);

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -538,8 +538,10 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
   }
 
   function _enableAutomaticClaim(uint256 _circleId, address _member) internal {
+    assertFalse(automaticSavingCircles.isAutomaticClaimsEnabled(_circleId, _member));
     vm.prank(_member);
     automaticSavingCircles.setAutomaticClaimsEnabled(_circleId, true);
+    assertTrue(automaticSavingCircles.isAutomaticClaimsEnabled(_circleId, _member));
   }
 
   function _createStartedCircle() internal returns (uint256) {

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -552,6 +552,21 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     assertFalse(savingCircles.hasClaimed(baseCircleId, alice));
   }
 
+  function test_BatchExecuteAutomatedClaims_ReportsUnknownCircleBeforeDisabledClaim() external {
+    uint256 invalidCircleId = savingCircles.nextId();
+    uint256[] memory circleIds = new uint256[](1);
+    address[] memory targetMembers = new address[](1);
+    circleIds[0] = invalidCircleId;
+    targetMembers[0] = alice;
+
+    vm.prank(gelatoExecutor);
+    vm.expectEmit(true, true, false, true, address(automaticSavingCircles));
+    emit IAutomaticSavingCircles.AutomatedClaimFailed(
+      invalidCircleId, alice, abi.encodeWithSelector(ISavingCircles.NotCommissioned.selector)
+    );
+    automaticSavingCircles.batchExecuteAutomatedClaims(circleIds, targetMembers);
+  }
+
   function test_BatchExecuteAutomatedClaims_RevertsOnMismatchedArrays() external {
     uint256[] memory circleIds = new uint256[](1);
     address[] memory targetMembers = new address[](0);

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -85,6 +85,24 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     assertFalse(automaticSavingCircles.isAutomaticDepositsEnabled(alice));
   }
 
+  function test_SetAutomaticClaimsEnabled() external {
+    assertFalse(automaticSavingCircles.isAutomaticClaimsEnabled(baseCircleId, alice));
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAutomaticSavingCircles.AutomaticClaimsToggled(baseCircleId, alice, true);
+    automaticSavingCircles.setAutomaticClaimsEnabled(baseCircleId, true);
+
+    assertTrue(automaticSavingCircles.isAutomaticClaimsEnabled(baseCircleId, alice));
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAutomaticSavingCircles.AutomaticClaimsToggled(baseCircleId, alice, false);
+    automaticSavingCircles.setAutomaticClaimsEnabled(baseCircleId, false);
+
+    assertFalse(automaticSavingCircles.isAutomaticClaimsEnabled(baseCircleId, alice));
+  }
+
   function test_SetAutomationExecutor() external {
     address newExecutor = makeAddr('newExecutor');
 
@@ -339,6 +357,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
 
   function test_GetEligibleAutomatedClaims_ReturnsOnlyWhenAllMembersDepositedAndRoundTimePassed() external {
     _depositRound(baseCircleId);
+    _enableAutomaticClaim(baseCircleId, alice);
 
     (uint256[] memory circleIdsBefore, address[] memory targetMembersBefore) =
       automaticSavingCircles.getEligibleAutomatedClaims();
@@ -358,6 +377,8 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
   }
 
   function test_GetEligibleAutomatedClaims_ReturnsFalseWhenRoundTimePassedButDepositsIncomplete() external {
+    _enableAutomaticClaim(baseCircleId, alice);
+
     token.mint(alice, DEPOSIT_AMOUNT);
     vm.startPrank(alice);
     token.approve(address(savingCircles), DEPOSIT_AMOUNT);
@@ -373,10 +394,29 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     assertEq(targetMembers.length, 0);
   }
 
+  function test_GetEligibleAutomatedClaims_ReturnsOnlyEnabledCircleForMember() external {
+    uint256 secondCircleId = _createStartedCircle();
+    _depositRound(baseCircleId);
+    _depositRound(secondCircleId);
+    _enableAutomaticClaim(baseCircleId, alice);
+
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
+
+    (uint256[] memory circleIds, address[] memory targetMembers) = automaticSavingCircles.getEligibleAutomatedClaims();
+
+    assertEq(circleIds.length, 1);
+    assertEq(targetMembers.length, 1);
+    assertEq(circleIds[0], baseCircleId);
+    assertEq(targetMembers[0], alice);
+  }
+
   function test_ClaimCheckerPayload_ClaimsForEligibleMembersAcrossAllCircles() external {
     uint256 secondCircleId = _createStartedCircle();
     _depositRound(baseCircleId);
     _depositRound(secondCircleId);
+    _enableAutomaticClaim(baseCircleId, alice);
+    _enableAutomaticClaim(secondCircleId, alice);
 
     ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
     vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
@@ -399,6 +439,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
 
   function test_ClaimChecker_ReturnsFalseWhenAutomationExecutorUnset() external {
     _depositRound(baseCircleId);
+    _enableAutomaticClaim(baseCircleId, alice);
 
     ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
     vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
@@ -430,6 +471,8 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
 
   function test_BatchExecuteAutomatedClaims_ContinuesWhenOneTargetFails() external {
     _depositRound(baseCircleId);
+    _enableAutomaticClaim(baseCircleId, bob);
+    _enableAutomaticClaim(baseCircleId, alice);
 
     ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
     vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
@@ -453,6 +496,27 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     assertEq(token.balanceOf(alice), DEPOSIT_AMOUNT * members.length);
   }
 
+  function test_BatchExecuteAutomatedClaims_DoesNotClaimForMemberWithoutOptIn() external {
+    _depositRound(baseCircleId);
+
+    ISavingCircles.Circle memory circle = savingCircles.getCircle(baseCircleId);
+    vm.warp(circle.effectiveCircleStartTime + DEPOSIT_INTERVAL);
+
+    uint256[] memory circleIds = new uint256[](1);
+    address[] memory targetMembers = new address[](1);
+    circleIds[0] = baseCircleId;
+    targetMembers[0] = alice;
+
+    vm.prank(gelatoExecutor);
+    vm.expectEmit(true, true, false, true, address(automaticSavingCircles));
+    emit IAutomaticSavingCircles.AutomatedClaimFailed(
+      baseCircleId, alice, abi.encodeWithSelector(IAutomaticSavingCircles.AutomaticClaimsNotEnabled.selector)
+    );
+    automaticSavingCircles.batchExecuteAutomatedClaims(circleIds, targetMembers);
+
+    assertFalse(savingCircles.hasClaimed(baseCircleId, alice));
+  }
+
   function test_BatchExecuteAutomatedClaims_RevertsOnMismatchedArrays() external {
     uint256[] memory circleIds = new uint256[](1);
     address[] memory targetMembers = new address[](0);
@@ -471,6 +535,11 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
 
     vm.prank(_member);
     token.approve(address(automaticSavingCircles), _amount);
+  }
+
+  function _enableAutomaticClaim(uint256 _circleId, address _member) internal {
+    vm.prank(_member);
+    automaticSavingCircles.setAutomaticClaimsEnabled(_circleId, true);
   }
 
   function _createStartedCircle() internal returns (uint256) {

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -510,7 +510,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     vm.prank(gelatoExecutor);
     vm.expectEmit(true, true, false, true, address(automaticSavingCircles));
     emit IAutomaticSavingCircles.AutomatedClaimFailed(
-      baseCircleId, alice, abi.encodeWithSelector(IAutomaticSavingCircles.AutomaticClaimsNotEnabled.selector)
+      baseCircleId, alice, abi.encodeWithSelector(IAutomaticSavingCircles.AutomaticClaimsDisabled.selector)
     );
     automaticSavingCircles.batchExecuteAutomatedClaims(circleIds, targetMembers);
 

--- a/test/unit/AutomaticSavingCircles.t.sol
+++ b/test/unit/AutomaticSavingCircles.t.sol
@@ -68,21 +68,21 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
   }
 
   function test_SetAutomaticDepositsEnabled() external {
-    assertFalse(automaticSavingCircles.isAutomaticDepositsEnabled(alice));
+    assertFalse(automaticSavingCircles.isAutomaticDepositsEnabled(baseCircleId, alice));
 
     vm.prank(alice);
     vm.expectEmit(true, true, true, true);
-    emit IAutomaticSavingCircles.AutomaticDepositsToggled(alice, true);
-    automaticSavingCircles.setAutomaticDepositsEnabled(true);
+    emit IAutomaticSavingCircles.AutomaticDepositsToggled(baseCircleId, alice, true);
+    automaticSavingCircles.setAutomaticDepositsEnabled(baseCircleId, true);
 
-    assertTrue(automaticSavingCircles.isAutomaticDepositsEnabled(alice));
+    assertTrue(automaticSavingCircles.isAutomaticDepositsEnabled(baseCircleId, alice));
 
     vm.prank(alice);
     vm.expectEmit(true, true, true, true);
-    emit IAutomaticSavingCircles.AutomaticDepositsToggled(alice, false);
-    automaticSavingCircles.setAutomaticDepositsEnabled(false);
+    emit IAutomaticSavingCircles.AutomaticDepositsToggled(baseCircleId, alice, false);
+    automaticSavingCircles.setAutomaticDepositsEnabled(baseCircleId, false);
 
-    assertFalse(automaticSavingCircles.isAutomaticDepositsEnabled(alice));
+    assertFalse(automaticSavingCircles.isAutomaticDepositsEnabled(baseCircleId, alice));
   }
 
   function test_SetAutomaticClaimsEnabled() external {
@@ -124,9 +124,12 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     uint256 secondCircleId = _createStartedCircle();
     uint256 totalRequiredPerMember = DEPOSIT_AMOUNT * 2;
 
-    _fundEnableAndApprove(alice, totalRequiredPerMember);
-    _fundEnableAndApprove(bob, totalRequiredPerMember);
-    _fundEnableAndApprove(carol, totalRequiredPerMember);
+    _fundEnableAndApprove(baseCircleId, alice, totalRequiredPerMember);
+    _fundEnableAndApprove(baseCircleId, bob, totalRequiredPerMember);
+    _fundEnableAndApprove(baseCircleId, carol, totalRequiredPerMember);
+    _enableAutomaticDeposit(secondCircleId, alice);
+    _enableAutomaticDeposit(secondCircleId, bob);
+    _enableAutomaticDeposit(secondCircleId, carol);
 
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
     assertTrue(canExec);
@@ -147,10 +150,11 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
   function test_GetEligibleAutomatedDeposits_ReturnsOnlyEligibleTargets() external {
     uint256 unstartedCircleId = _createUnstartedCircle();
 
-    _fundEnableAndApprove(alice, DEPOSIT_AMOUNT);
+    _fundEnableAndApprove(baseCircleId, alice, DEPOSIT_AMOUNT);
+    _enableAutomaticDeposit(unstartedCircleId, alice);
 
     vm.prank(bob);
-    automaticSavingCircles.setAutomaticDepositsEnabled(true);
+    automaticSavingCircles.setAutomaticDepositsEnabled(baseCircleId, true);
 
     (uint256[] memory circleIds, address[] memory targetMembers) = automaticSavingCircles.getEligibleAutomatedDeposits();
 
@@ -162,17 +166,32 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     assertFalse(circleIds[0] == unstartedCircleId);
   }
 
+  function test_GetEligibleAutomatedDeposits_ReturnsOnlyEnabledCircleForMember() external {
+    uint256 secondCircleId = _createStartedCircle();
+    _fundEnableAndApprove(baseCircleId, alice, DEPOSIT_AMOUNT * 2);
+
+    (uint256[] memory circleIds, address[] memory targetMembers) = automaticSavingCircles.getEligibleAutomatedDeposits();
+
+    assertEq(circleIds.length, 1);
+    assertEq(targetMembers.length, 1);
+    assertEq(circleIds[0], baseCircleId);
+    assertEq(targetMembers[0], alice);
+    assertFalse(circleIds[0] == secondCircleId);
+  }
+
   function test_CheckerPayload_SkipsIneligibleMembersAndUnstartedCircles() external {
     uint256 unstartedCircleId = _createUnstartedCircle();
 
-    _fundEnableAndApprove(alice, DEPOSIT_AMOUNT * 2);
+    _fundEnableAndApprove(baseCircleId, alice, DEPOSIT_AMOUNT * 2);
+    _enableAutomaticDeposit(unstartedCircleId, alice);
 
     token.mint(bob, DEPOSIT_AMOUNT);
     vm.prank(bob);
-    automaticSavingCircles.setAutomaticDepositsEnabled(true);
+    automaticSavingCircles.setAutomaticDepositsEnabled(baseCircleId, true);
 
     vm.prank(carol);
-    automaticSavingCircles.setAutomaticDepositsEnabled(true);
+    automaticSavingCircles.setAutomaticDepositsEnabled(baseCircleId, true);
+    _enableAutomaticDeposit(unstartedCircleId, carol);
 
     vm.prank(carol);
     token.approve(address(automaticSavingCircles), DEPOSIT_AMOUNT);
@@ -203,7 +222,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     vm.stopPrank();
 
     vm.prank(alice);
-    automaticSavingCircles.setAutomaticDepositsEnabled(true);
+    automaticSavingCircles.setAutomaticDepositsEnabled(baseCircleId, true);
 
     vm.prank(alice);
     token.approve(address(automaticSavingCircles), partialAmount);
@@ -220,9 +239,12 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     uint256 secondCircleId = _createStartedCircle();
     uint256 totalRequiredPerMember = DEPOSIT_AMOUNT * 2;
 
-    _fundEnableAndApprove(alice, totalRequiredPerMember);
-    _fundEnableAndApprove(bob, totalRequiredPerMember);
-    _fundEnableAndApprove(carol, totalRequiredPerMember);
+    _fundEnableAndApprove(baseCircleId, alice, totalRequiredPerMember);
+    _fundEnableAndApprove(baseCircleId, bob, totalRequiredPerMember);
+    _fundEnableAndApprove(baseCircleId, carol, totalRequiredPerMember);
+    _enableAutomaticDeposit(secondCircleId, alice);
+    _enableAutomaticDeposit(secondCircleId, bob);
+    _enableAutomaticDeposit(secondCircleId, carol);
 
     (uint256[] memory circleIds, address[] memory targetMembers) = automaticSavingCircles.getEligibleAutomatedDeposits();
 
@@ -238,11 +260,30 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     assertEq(savingCircles.balances(secondCircleId, carol), DEPOSIT_AMOUNT);
   }
 
+  function test_BatchExecuteAutomatedDeposits_DoesNotDepositForMemberWithoutOptInInCircle() external {
+    uint256 secondCircleId = _createStartedCircle();
+    _fundEnableAndApprove(baseCircleId, alice, DEPOSIT_AMOUNT);
+
+    uint256[] memory circleIds = new uint256[](1);
+    address[] memory targetMembers = new address[](1);
+    circleIds[0] = secondCircleId;
+    targetMembers[0] = alice;
+
+    vm.prank(gelatoExecutor);
+    vm.expectEmit(true, true, false, true, address(automaticSavingCircles));
+    emit IAutomaticSavingCircles.AutomatedDepositFailed(
+      secondCircleId, alice, abi.encodeWithSelector(IAutomaticSavingCircles.AutomaticDepositsNotEnabled.selector)
+    );
+    automaticSavingCircles.batchExecuteAutomatedDeposits(circleIds, targetMembers);
+
+    assertEq(savingCircles.balances(secondCircleId, alice), 0);
+  }
+
   function test_BatchExecuteAutomatedDeposits_ContinuesWhenOneTargetFails() external {
-    _fundEnableAndApprove(alice, DEPOSIT_AMOUNT);
+    _fundEnableAndApprove(baseCircleId, alice, DEPOSIT_AMOUNT);
 
     vm.prank(bob);
-    automaticSavingCircles.setAutomaticDepositsEnabled(true);
+    automaticSavingCircles.setAutomaticDepositsEnabled(baseCircleId, true);
 
     uint256[] memory circleIds = new uint256[](2);
     address[] memory targetMembers = new address[](2);
@@ -290,7 +331,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
   }
 
   function test_Checker_ReturnsTrueAndExecPayloadWhenAnyEligibleMemberExists() external {
-    _fundEnableAndApprove(alice, DEPOSIT_AMOUNT);
+    _fundEnableAndApprove(baseCircleId, alice, DEPOSIT_AMOUNT);
     (uint256[] memory circleIds, address[] memory targetMembers) = automaticSavingCircles.getEligibleAutomatedDeposits();
 
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
@@ -302,7 +343,7 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
   }
 
   function test_Checker_ReturnsFalseWhenAutomationExecutorUnset() external {
-    _fundEnableAndApprove(alice, DEPOSIT_AMOUNT);
+    _fundEnableAndApprove(baseCircleId, alice, DEPOSIT_AMOUNT);
 
     vm.prank(owner);
     automaticSavingCircles.setAutomationExecutor(address(0));
@@ -322,15 +363,8 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
 
   function test_Checker_ReturnsFalseWhenOnlyUnstartedCirclesHaveEligibleMembers() external {
     _depositBaseCircleForAlice();
-    _createUnstartedCircle();
-
-    token.mint(alice, DEPOSIT_AMOUNT * 2);
-
-    vm.prank(alice);
-    automaticSavingCircles.setAutomaticDepositsEnabled(true);
-
-    vm.prank(alice);
-    token.approve(address(automaticSavingCircles), DEPOSIT_AMOUNT * 2);
+    uint256 unstartedCircleId = _createUnstartedCircle();
+    _fundEnableAndApprove(unstartedCircleId, alice, DEPOSIT_AMOUNT * 2);
 
     (bool canExec, bytes memory execPayload) = automaticSavingCircles.depositChecker();
 
@@ -345,7 +379,8 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     vm.prank(alice);
     savingCircles.decommission(decommissionedCircleId);
 
-    _fundEnableAndApprove(alice, DEPOSIT_AMOUNT);
+    _fundEnableAndApprove(baseCircleId, alice, DEPOSIT_AMOUNT);
+    _enableAutomaticDeposit(decommissionedCircleId, alice);
 
     (uint256[] memory circleIds, address[] memory targetMembers) = automaticSavingCircles.getEligibleAutomatedDeposits();
 
@@ -527,14 +562,20 @@ contract AutomaticSavingCirclesUnit is SavingCirclesTestBase {
     automaticSavingCircles.batchExecuteAutomatedClaims(circleIds, targetMembers);
   }
 
-  function _fundEnableAndApprove(address _member, uint256 _amount) internal {
+  function _fundEnableAndApprove(uint256 _circleId, address _member, uint256 _amount) internal {
     token.mint(_member, _amount);
 
-    vm.prank(_member);
-    automaticSavingCircles.setAutomaticDepositsEnabled(true);
+    _enableAutomaticDeposit(_circleId, _member);
 
     vm.prank(_member);
     token.approve(address(automaticSavingCircles), _amount);
+  }
+
+  function _enableAutomaticDeposit(uint256 _circleId, address _member) internal {
+    assertFalse(automaticSavingCircles.isAutomaticDepositsEnabled(_circleId, _member));
+    vm.prank(_member);
+    automaticSavingCircles.setAutomaticDepositsEnabled(_circleId, true);
+    assertTrue(automaticSavingCircles.isAutomaticDepositsEnabled(_circleId, _member));
   }
 
   function _enableAutomaticClaim(uint256 _circleId, address _member) internal {


### PR DESCRIPTION
## Summary

Adds per-circle user opt-in for automatic claims processed through `AutomaticSavingCircles`.

Users can now enable or disable automated claims independently for each saving circle, and Gelato will execute eligible opted-in claims in shared batches.

## Changes

- Added `setAutomaticClaimsEnabled(uint256 circleId, bool enabled)`.
- Added `isAutomaticClaimsEnabled(uint256 circleId, address member).`
- Added per-circle/member automatic claim preference storage.
- Added `AutomaticClaimsToggled` event.
- Added `AutomaticClaimsNotEnabled` error.
- Updated claim eligibility selection to include only opted-in `(circleId, member)` pairs.
- Revalidated opt-in during batch execution so executor-supplied targets cannot bypass user preference.
- Added unit tests for claim opt-in toggling, per-circle filtering, batch execution protection, and existing batched claim behavior.

## Scope

This PR changes automatic claims only.

Automatic deposits are outside MVP scope. Existing deposit opt-in remains member-wide across all eligible circles and must be revisited before deposit automation is exposed through the frontend or enabled in Gelato.
