### PR TITLE
feat: Variant D — the foremanless chit (reverse-auction saving circle)

### DIFF
--- a/docs/variant-d-foremanless-chit.md
+++ b/docs/variant-d-foremanless-chit.md
@@ -1,0 +1,147 @@
+# Variant D — The Foremanless Chit
+
+*A permissionless, capital-efficient reverse-auction saving circle. On-chain compilation of the
+Indian chit fund (Chit Funds Act, 1982), extending F. Badaloni's* Saving Circles — Specification.
+
+This document is the design rationale for `src/contracts/ChitSavingCircles.sol`. It is the fourth
+of four collateralized permissionless ROSCA designs; the full comparative spec (Variants A–D, with
+the Deckstacking / Bartoletti–Zunino contract-semantics model and all proofs) lives in
+[breadchainCoop/saving-circles #182](https://github.com/BreadchainCoop/saving-circles/pull/182).
+Variant A (collateral-first) is implemented there; **Variant D, implemented here, supersedes the
+rolling-bond Variant B** at roughly a quarter of the locked capital.
+
+---
+
+## 0. What problem it solves
+
+A plain ROSCA is secretly a loan: an early recipient takes the pot and is *trusted* to keep
+depositing. The baseline `SavingCircles` can only guarantee an honest saver recovers `(n − t)·m`
+against an adversary controlling `t` savers — the residual `t·m` is unsecured credit — which is
+why it must gate entry with owner-signed invites and freeze the cohort.
+
+The collateral variants (A, B) drive `t → 0` by making every member post security for their
+worst case, so nobody can be hurt and the door can open to anyone. But they over-pay: they
+collateralize **every** member for a **whole pot**, at all times.
+
+The chit fund shows this is ~4× too much. **Only a member who has already won can steal**, and only
+for what she still owes. So collateral should be demanded *at prize time* and *only for the exact
+residual*. Variant D does that, and — by allocating the pot with a reverse auction — it also pays
+patient members an endogenous interest rate that a fixed-rotation circle forces to zero.
+
+## 1. The mechanism
+
+A circle runs a single cycle of `n = numSlots` rounds. Every member deposits `m` every round.
+Exactly one member is *prized* (wins the pot) per round, so after `n` rounds everyone has won once.
+
+Each round `j` (0-indexed) has two phases inside its window:
+
+1. **Commit** (first part of the round): members `deposit(m)` and submit a sealed bid
+   `commitBid(H(discount, salt))`.
+2. **Reveal** (last `revealDuration` of the round): members `revealBid(discount, salt)`.
+
+After the round closes anyone calls `award()`, which settles rounds **strictly in order**.
+
+**Why sealed bids.** An open-outcry on-chain auction hands the block scheduler a last-look: censor
+rivals for a few blocks, then snipe with `d + ε`. That is auction MEV. The commit/reveal split (with
+the reveal phase carved out of the round) makes the auction robust to an adversarial scheduler in the
+Deckstacking sense — honest commitments and reveals are guaranteed inclusion, and `award` is a
+deterministic function of the revealed set. **No-bid rounds fall back to fixed rotation** (`d = 0`,
+lowest free slot), so a rotation ROSCA is D's degenerate case; the allocation rule is a parameter,
+not a commitment.
+
+### 1.1 Prize-time two-tier security — the safety core ("Theorem D3")
+
+At `award`, the winner of round `j` still owes her remaining `residual = (n − 1 − j)·m` of deposits.
+Her winning bid `d` is **withheld as first-loss security** instead of being paid out, and she locks
+the rest in cash:
+
+```
+withheld = d            coll = (n − 1 − j)·m − d            withheld + coll = residual
+```
+
+The immediate cash she receives is `(j + 1)·m` (`= n·m − d − coll`), funded entirely from the pot —
+**she posts no new capital**. A bigger bid means a smaller cash lock; you can never bid away more
+than you owe (`d ≤ residual`, replacing the Act's ad-hoc 30–40 % cap with a structural one).
+
+The invariant
+
+> **`withheld(x) + coll(x) == residual(x)`** for every prized `x`
+
+holds at award (with equality) and is preserved by every subsequent rule — both sides fall by exactly
+`m` per settled deposit. Therefore every future pot can be made whole against **any** set of prized
+defaulters, and **no honest member ever loses principal**. A would-be thief who bids high merely
+pre-pays her own first-loss cover: her realizable theft is `0` whatever she bids. (The unit test
+`test_PrizedDefault_TheftIsZero_HonestMembersWhole` bids the maximum and then defaults on every
+remaining deposit; every recipient is still paid in full and the defaulter nets zero.)
+
+### 1.2 Dividends = endogenous interest ("D6")
+
+As a prized member makes each on-time deposit, a slice `withheld / (rounds remaining)` of her withheld
+bid is released **pro-rata to the other members** (a credit they can `claim`), and the matching slice
+of her cash lock is returned to her. Over her residual period an honest winner pays out exactly her
+bid `d` — her interest — and recovers her whole cash lock. Patient members who win late with low bids
+are net **receivers** of interest; impatient early winners pay it. The interest market is zero-sum
+(`test_Auction_BidBecomesDividendInterest`: a member who bids `2m` ends `−2m`; the two others end
+`+m` each).
+
+### 1.3 Capital ("D4")
+
+Aggregate security held at the close of round `j` equals the outstanding-credit parabola
+`K(j) = (j + 1)(n − 1 − j)·m` plus the `n·m` of one-round bonds — within `n·m` of the
+information-theoretic floor, versus Variant B's `≈ 4×` it at peak.
+
+## 2. Non-prized default and churn
+
+A member who has **not** won owes nothing she has not already lent; her default is a coordination
+event, not a credit event. She posts a one-round **membership bond** of `m` at `join`. A missed
+deposit is covered from that bond and she is flagged defaulted, freeing her slot for permissionless
+`substitute` — a successor posts a fresh bond and assumes the slot, its future deposit schedule, and
+its prize eligibility (the Act's §§28–30). The defaulter forfeits her bond; no other member is
+affected, and the pot stays `n·m` (no resize).
+`test_Substitution_DefaultedSlotTakenOver_CircleCompletes` covers this.
+
+If a defaulted slot is **never** substituted, the circle can no longer complete a round. Anyone may
+then `abort`, which unwinds every member to **net-zero on principal**:
+`refund = deposits + bondsPosted − amountsWithdrawn` (≥ 0), clawing back unrealized prizes. Because
+every prized member's remaining obligation is fully secured (`withheld + coll == residual`), this
+exactly drains the circle's funds and **no honest member loses principal** — the worst case for an
+honest member is that a mid-cycle default forces an early, whole unwind
+(`test_Abort_StalledCircle_UnwindsEveryoneToNetZero`).
+
+## 3. Two honest limits (from the spec)
+
+- **Do not combine the auction with under-collateralization (Variant C).** A member who plans to
+  default is discount-insensitive; with thin collateral the auction routes pots to the worst risks
+  first (adverse selection) and drains the insurance buffer. The safe compositions are exactly
+  *auction + full prize-time security* (this contract) and *no-auction + under-collateral + slot
+  restriction + buffer* (Variant C). The combination is excluded.
+- **The trilemma (Prop. 5.4).** No design gives all three of (i) unconditional safety, (ii)
+  membership open to fresh anonymous keys, and (iii) positive net credit *in the circle's own asset*.
+  Same-asset Variant D chooses (i) and (ii), so net credit is `≤ 0`: it is a **commitment-savings +
+  mutual-insurance + interest-market** device, not a lender. Real credit content requires the
+  prize-time security to be *something other than same-asset cash* — heterogeneous collateral or an
+  on-chain surety (the Act's salaried co-signer, compiled) — which the design admits as a documented
+  extension point.
+
+## 4. Implementation scope (v1)
+
+Implemented: the sealed-bid auction, prize-time two-tier security, dividends, prized-default cover,
+no-bid rotation fallback, defaulted-slot substitution, and the net-zero abort valve — on a cohort
+fixed at `start`, with permissionless create / join / start (no owner, no invite). See the 16 unit
+tests in `test/unit/ChitSavingCirclesUnit.t.sol`.
+
+Deferred (documented extension points): continuous mid-cycle resize; voluntary (non-default)
+substitution with claim transfer; a Vickrey price rule (winner pays the second-highest discount) for
+truthful bidding in the price dimension; and heterogeneous / surety collateral for genuine credit.
+The contract is standalone and does not touch `SavingCircles` / `AutomaticSavingCircles`.
+
+---
+
+### References
+
+- M. Bartoletti, R. Zunino. *A Theoretical Basis for MEV.* FC 2025. (Deckstacking; sealed-bid rationale.)
+- F. Badaloni. *Saving Circles — Specification.* 2026. (Baseline extended here.)
+- Besley, Coate, Loury. *The Economics of Rotating Savings and Credit Associations.* AER 1993.
+- Kovsted, Lyk-Jensen. *ROSCAs: random vs. bidding allocation.* J. Dev. Econ. 1999.
+- *The Chit Funds Act, 1982* (Act No. 40 of 1982, India). §§28–30 substitution; discount and
+  commission caps; prized-subscriber security before draw.

--- a/src/contracts/ChitSavingCircles.sol
+++ b/src/contracts/ChitSavingCircles.sol
@@ -1,0 +1,596 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {ReentrancyGuardUpgradeable} from '@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+
+import {IChitSavingCircles} from 'interfaces/IChitSavingCircles.sol';
+
+using SafeERC20 for IERC20;
+
+/**
+ * @title Chit Saving Circles — Variant D, "the foremanless chit"
+ * @notice A permissionless, capital-efficient reverse-auction ROSCA with prize-time two-tier
+ *         collateral. See {IChitSavingCircles} and docs/collateralized-permissionless-circles.md
+ *         for the formal model.
+ * @dev Safety rests on one invariant, established at each {award} and preserved by every rule:
+ *      for every prized member `withheld(x) + coll(x) == residual(x)`, where `residual(x)` is the
+ *      exact value of `x`'s remaining deposit obligations. Because a member's remaining
+ *      obligation is always fully pre-funded by her own security, every pot is made whole against
+ *      any set of prized defaulters and no honest member ever subsidizes one ("Theorem D3").
+ *      Conservation holds by construction: covers and releases only move value between a member's
+ *      security, a member's claimable balance, and the round pot — never in or out of the
+ *      contract. Value enters only on {deposit}/{join}/{substitute} and leaves only on
+ *      {claim}/{reclaimBond}/{abort}.
+ * @author Breadchain Collective
+ */
+contract ChitSavingCircles is IChitSavingCircles, ReentrancyGuardUpgradeable, OwnableUpgradeable {
+  uint256 public constant MINIMUM_SLOTS = 2;
+
+  uint256 internal _nextId;
+
+  mapping(address token => bool allowed) internal _allowedTokens;
+  mapping(uint256 id => Circle circle) internal _circles;
+  mapping(uint256 id => address[] members) internal _members;
+  // Append-only roster of every address ever substituted out of a slot, so {abort} can still
+  // refund a defaulter's forfeited stake after {substitute} removed them from `_members`.
+  mapping(uint256 id => address[] formerMembers) internal _formerMembers;
+  mapping(uint256 id => mapping(address member => bool isMember)) internal _isMember;
+  mapping(uint256 id => mapping(address member => uint256 slot)) internal _memberSlot;
+
+  // Per-member security and status.
+  mapping(uint256 id => mapping(address member => uint256 amount)) internal _coll; // cash lock (prized)
+  mapping(uint256 id => mapping(address member => uint256 amount)) internal _withheld; // withheld bid (prized)
+  mapping(uint256 id => mapping(address member => uint256 amount)) internal _bond; // remaining membership bond
+  mapping(uint256 id => mapping(address member => uint256 count)) internal _remaining; // owed future deposits
+  mapping(uint256 id => mapping(address member => bool prized)) internal _prized;
+  mapping(uint256 id => mapping(address member => uint256 round)) internal _prizeRound;
+  mapping(uint256 id => mapping(address member => bool defaulted)) internal _defaulted;
+
+  // Cash ledgers.
+  mapping(uint256 id => mapping(address member => uint256 amount)) internal _claimable; // withdrawable now
+  mapping(uint256 id => mapping(address member => uint256 amount)) internal _deposited; // cumulative deposits
+  mapping(uint256 id => mapping(address member => uint256 amount)) internal _bondPosted; // cumulative bonds
+  mapping(uint256 id => mapping(address member => uint256 amount)) internal _withdrawn; // cumulative claimed out
+
+  // Per-round bookkeeping.
+  mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 amount))) internal _roundDeposit;
+  mapping(uint256 id => mapping(uint256 round => uint256 amount)) internal _roundPot;
+  mapping(uint256 id => mapping(uint256 round => mapping(address member => bytes32 h))) internal _commitment;
+  mapping(uint256 id => mapping(uint256 round => mapping(address member => uint256 discount))) internal _bid;
+  mapping(uint256 id => mapping(uint256 round => mapping(address member => bool revealed))) internal _revealed;
+
+  mapping(uint256 id => uint256 count) internal _awardedCount;
+  mapping(uint256 id => bool aborted) internal _aborted;
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function initialize(address owner) external override initializer {
+    __Ownable_init(owner);
+    __ReentrancyGuard_init();
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function setTokenAllowed(address token, bool allowed) external override onlyOwner {
+    _allowedTokens[token] = allowed;
+    emit TokenAllowed(token, allowed);
+  }
+
+  // =======================
+  // LIFECYCLE
+  // =======================
+
+  /// @inheritdoc IChitSavingCircles
+  function createCircle(
+    address token,
+    uint256 depositAmount,
+    uint256 numSlots,
+    uint256 roundDuration,
+    uint256 revealDuration
+  ) external override returns (uint256 id) {
+    if (!_allowedTokens[token]) revert TokenNotAllowed();
+    if (depositAmount == 0 || numSlots < MINIMUM_SLOTS || roundDuration == 0) revert InvalidParameters();
+    if (revealDuration == 0 || revealDuration >= roundDuration) revert InvalidParameters();
+
+    id = _nextId++;
+    _circles[id] = Circle({
+      token: token,
+      depositAmount: depositAmount,
+      numSlots: numSlots,
+      roundDuration: roundDuration,
+      revealDuration: revealDuration,
+      startTime: 0
+    });
+
+    emit CircleCreated(id, token, depositAmount, numSlots, roundDuration, revealDuration);
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function join(uint256 id) external override nonReentrant {
+    Circle storage circle = _existing(id);
+    if (circle.startTime != 0) revert CircleNotOpen();
+    if (_members[id].length >= circle.numSlots) revert CircleNotOpen();
+    if (_isMember[id][msg.sender]) revert AlreadyMember();
+
+    uint256 slot = _members[id].length;
+    _members[id].push(msg.sender);
+    _isMember[id][msg.sender] = true;
+    _memberSlot[id][msg.sender] = slot;
+
+    uint256 m = circle.depositAmount;
+    _bond[id][msg.sender] = m;
+    _bondPosted[id][msg.sender] += m;
+    IERC20(circle.token).safeTransferFrom(msg.sender, address(this), m);
+
+    emit MemberJoined(id, msg.sender, slot);
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function start(uint256 id) external override {
+    Circle storage circle = _existing(id);
+    if (circle.startTime != 0) revert WrongState();
+    if (_members[id].length != circle.numSlots) revert CircleNotFull();
+
+    circle.startTime = block.timestamp;
+    emit CircleStarted(id, block.timestamp);
+  }
+
+  // =======================
+  // DEPOSITS
+  // =======================
+
+  /// @inheritdoc IChitSavingCircles
+  function deposit(uint256 id, uint256 value) external override nonReentrant {
+    _deposit(id, msg.sender, value);
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function depositFor(uint256 id, address member, uint256 value) external override nonReentrant {
+    _deposit(id, member, value);
+  }
+
+  function _deposit(uint256 id, address member, uint256 value) internal {
+    Circle storage circle = _existing(id);
+    if (circle.startTime == 0 || _aborted[id]) revert WrongState();
+    if (!_isMember[id][member]) revert NotMember();
+    if (value == 0) revert InvalidParameters();
+
+    uint256 t = _round(circle);
+    if (t >= circle.numSlots) revert WrongState(); // cycle over
+
+    uint256 newTotal = _roundDeposit[id][t][member] + value;
+    if (newTotal > circle.depositAmount) revert ExceedsDepositAmount();
+
+    _roundDeposit[id][t][member] = newTotal;
+    _roundPot[id][t] += value;
+    _deposited[id][member] += value;
+
+    IERC20(circle.token).safeTransferFrom(msg.sender, address(this), value);
+    emit Deposited(id, member, t, value);
+  }
+
+  // =======================
+  // SEALED-BID AUCTION
+  // =======================
+
+  /// @inheritdoc IChitSavingCircles
+  function commitBid(uint256 id, bytes32 commitment) external override {
+    Circle storage circle = _existing(id);
+    uint256 t = _biddableRound(id, circle);
+    if (_phase(circle) != Phase.Commit) revert WrongPhase();
+    if (_commitment[id][t][msg.sender] != bytes32(0)) revert AlreadyCommitted();
+
+    _commitment[id][t][msg.sender] = commitment;
+    emit BidCommitted(id, msg.sender, t);
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function revealBid(uint256 id, uint256 discount, bytes32 salt) external override {
+    Circle storage circle = _existing(id);
+    uint256 t = _biddableRound(id, circle);
+    if (_phase(circle) != Phase.Reveal) revert WrongPhase();
+
+    bytes32 h = _commitment[id][t][msg.sender];
+    if (h == bytes32(0) || h != keccak256(abi.encode(discount, salt, msg.sender, id, t))) revert InvalidReveal();
+    if (_roundDeposit[id][t][msg.sender] < circle.depositAmount) revert NotCurrent();
+    if (discount > (circle.numSlots - 1 - t) * circle.depositAmount) revert BidTooHigh();
+
+    _bid[id][t][msg.sender] = discount;
+    _revealed[id][t][msg.sender] = true;
+    emit BidRevealed(id, msg.sender, t, discount);
+  }
+
+  /// @dev Shared guards for {commitBid}/{revealBid}: an active, non-prized, non-defaulted member
+  ///      bidding on the current, in-cycle round. Returns the current round index `t`.
+  function _biddableRound(uint256 id, Circle storage circle) internal view returns (uint256 t) {
+    if (circle.startTime == 0 || _aborted[id]) revert WrongState();
+    if (!_isMember[id][msg.sender]) revert NotMember();
+    if (_prized[id][msg.sender]) revert AlreadyPrized();
+    if (_defaulted[id][msg.sender]) revert MemberIsDefaulted();
+    t = _round(circle);
+    if (t >= circle.numSlots) revert WrongState();
+  }
+
+  // =======================
+  // AWARD / SETTLEMENT
+  // =======================
+
+  /// @inheritdoc IChitSavingCircles
+  function award(uint256 id) external override nonReentrant {
+    Circle storage circle = _existing(id);
+    if (circle.startTime == 0 || _aborted[id]) revert WrongState();
+
+    uint256 n = circle.numSlots;
+    uint256 m = circle.depositAmount;
+    uint256 f = _awardedCount[id];
+    if (f >= n) revert WrongState(); // all rounds awarded
+    if (_round(circle) <= f) revert RoundNotClosed(); // round f still open
+
+    address[] memory members = _members[id];
+
+    // (1) Complete the pot: cover every non-depositor's missed `m` from her own security.
+    _coverNonDepositors(id, f, m, members);
+
+    // (2) Choose the winner: highest revealed discount among eligible depositors, else rotation.
+    (address winner, uint256 discount) = _selectWinner(id, f, m, members);
+
+    // (3) Pay the winner and lock her exact residual as `withheld (= bid) + coll (= rest)`.
+    uint256 residual = (n - 1 - f) * m;
+    uint256 lock = residual - discount; // discount <= residual, enforced at reveal
+    _prized[id][winner] = true;
+    _prizeRound[id][winner] = f;
+    _withheld[id][winner] = discount;
+    _coll[id][winner] = lock;
+    _remaining[id][winner] = n - 1 - f;
+    _claimable[id][winner] += (f + 1) * m; // == n*m - discount - lock
+    emit Awarded(id, winner, f, discount, (f + 1) * m, lock);
+
+    // (4) Release one matured installment of every earlier winner who deposited this round.
+    _releaseMatured(id, f, m, members);
+
+    _roundPot[id][f] = 0;
+    _awardedCount[id] = f + 1;
+  }
+
+  /// @dev Draw `m` into the pot for each member who did not deposit round `f`.
+  function _coverNonDepositors(uint256 id, uint256 f, uint256 m, address[] memory members) internal {
+    for (uint256 i = 0; i < members.length; i++) {
+      address x = members[i];
+      if (_roundDeposit[id][f][x] >= m) continue; // deposited in full
+      if (_prized[id][x]) {
+        // Prized: cover from withheld first, then cash lock. Solvent because withheld + coll ==
+        // remaining*m >= m while an obligation is outstanding.
+        uint256 fromWithheld = _withheld[id][x] >= m ? m : _withheld[id][x];
+        _withheld[id][x] -= fromWithheld;
+        _coll[id][x] -= (m - fromWithheld);
+        _remaining[id][x] -= 1;
+        emit Covered(id, x, f, m);
+      } else {
+        // Non-prized: cover from the one-round bond and flag defaulted. If the bond is already
+        // spent the round cannot be completed; revert so the circle can be {abort}ed.
+        if (_bond[id][x] < m) revert NotAwardable();
+        _bond[id][x] -= m;
+        _defaulted[id][x] = true;
+        emit BondCovered(id, x, f, m);
+        emit MemberDefaulted(id, x);
+      }
+    }
+  }
+
+  /// @dev Highest revealed discount among current, unprized, non-defaulted members wins; ties and
+  ///      the no-bid case fall back to the lowest-slot eligible member at discount 0.
+  function _selectWinner(
+    uint256 id,
+    uint256 f,
+    uint256 m,
+    address[] memory members
+  ) internal view returns (address winner, uint256 discount) {
+    bool found;
+    for (uint256 i = 0; i < members.length; i++) {
+      address x = members[i];
+      if (_prized[id][x] || _defaulted[id][x] || _roundDeposit[id][f][x] < m) continue;
+      if (_revealed[id][f][x] && (!found || _bid[id][f][x] > discount)) {
+        found = true;
+        winner = x;
+        discount = _bid[id][f][x];
+      }
+    }
+    if (found) return (winner, discount);
+
+    // No valid bids: rotate to the lowest-slot eligible depositor.
+    for (uint256 i = 0; i < members.length; i++) {
+      address x = members[i];
+      if (_prized[id][x] || _defaulted[id][x] || _roundDeposit[id][f][x] < m) continue;
+      return (x, 0);
+    }
+    revert NoEligibleWinner();
+  }
+
+  /// @dev For every member prized before round `f` who deposited round `f`, unlock one installment:
+  ///      return `m - dividend` of her cash lock and pay `dividend` out to the others as interest.
+  function _releaseMatured(uint256 id, uint256 f, uint256 m, address[] memory members) internal {
+    for (uint256 i = 0; i < members.length; i++) {
+      address x = members[i];
+      if (!_prized[id][x] || _prizeRound[id][x] >= f) continue; // not an earlier winner
+      if (_roundDeposit[id][f][x] < m) continue; // missed → already covered in step (1)
+
+      uint256 rem = _remaining[id][x];
+      uint256 dividend = _withheld[id][x] / rem; // floor; the final installment takes the remainder
+      _withheld[id][x] -= dividend;
+      uint256 collBack = m - dividend;
+      _coll[id][x] -= collBack;
+      _remaining[id][x] = rem - 1;
+      _claimable[id][x] += collBack;
+
+      _distributeDividend(id, x, dividend, members);
+      emit SecurityReleased(id, x, f, collBack, dividend);
+    }
+  }
+
+  /// @dev Split `amount` equally among all members except `payer`; any rounding dust stays with
+  ///      the payer, so the distribution is exact.
+  function _distributeDividend(uint256 id, address payer, uint256 amount, address[] memory members) internal {
+    if (amount == 0) return;
+    uint256 share = amount / (members.length - 1);
+    uint256 distributed;
+    for (uint256 i = 0; i < members.length; i++) {
+      address x = members[i];
+      if (x == payer) continue;
+      _claimable[id][x] += share;
+      distributed += share;
+    }
+    _claimable[id][payer] += (amount - distributed); // dust back to payer
+  }
+
+  // =======================
+  // CLAIMS / EXITS
+  // =======================
+
+  /// @inheritdoc IChitSavingCircles
+  function claim(uint256 id) external override nonReentrant {
+    Circle storage circle = _existing(id);
+    uint256 amount = _claimable[id][msg.sender];
+    if (amount == 0) revert NothingToClaim();
+
+    _claimable[id][msg.sender] = 0;
+    _withdrawn[id][msg.sender] += amount;
+    IERC20(circle.token).safeTransfer(msg.sender, amount);
+    emit Claimed(id, msg.sender, amount);
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function substitute(uint256 id, address oldMember) external override nonReentrant {
+    Circle storage circle = _existing(id);
+    if (circle.startTime == 0 || _aborted[id]) revert WrongState();
+    if (_round(circle) >= circle.numSlots) revert WrongState();
+    if (!_isMember[id][oldMember]) revert NotMember();
+    if (_prized[id][oldMember] || !_defaulted[id][oldMember]) revert NotSubstitutable();
+    if (_isMember[id][msg.sender]) revert AlreadyMember();
+
+    uint256 slot = _memberSlot[id][oldMember];
+    _isMember[id][oldMember] = false;
+    _isMember[id][msg.sender] = true;
+    _memberSlot[id][msg.sender] = slot;
+    _members[id][slot] = msg.sender;
+    // Preserve the forfeiting member on the historical roster so {abort} still drains their stake.
+    _formerMembers[id].push(oldMember);
+
+    uint256 m = circle.depositAmount;
+    _bond[id][msg.sender] = m;
+    _bondPosted[id][msg.sender] += m;
+    _defaulted[id][msg.sender] = false;
+    _prized[id][msg.sender] = false;
+
+    IERC20(circle.token).safeTransferFrom(msg.sender, address(this), m);
+    emit MemberSubstituted(id, oldMember, msg.sender, slot);
+    emit MemberJoined(id, msg.sender, slot);
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function reclaimBond(uint256 id) external override nonReentrant {
+    Circle storage circle = _existing(id);
+    if (_aborted[id]) revert WrongState();
+    if (_awardedCount[id] != circle.numSlots) revert WrongState(); // must have ended
+    if (!_isMember[id][msg.sender]) revert NotMember();
+
+    uint256 amount = _bond[id][msg.sender];
+    if (amount == 0) revert NothingToClaim();
+
+    _bond[id][msg.sender] = 0;
+    IERC20(circle.token).safeTransfer(msg.sender, amount);
+    emit BondReclaimed(id, msg.sender, amount);
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function abort(uint256 id) external override nonReentrant {
+    Circle storage circle = _existing(id);
+    if (circle.startTime == 0 || _aborted[id]) revert WrongState();
+    uint256 n = circle.numSlots;
+    uint256 f = _awardedCount[id];
+    // Stalled == the next round has closed but cannot be made whole (a defaulted slot, no substitute).
+    if (f >= n || _round(circle) <= f || _awardableCore(id, f, circle.depositAmount)) revert NotStuck();
+
+    _aborted[id] = true;
+
+    // Net-zero unwind: refund every current AND substituted-out member their
+    // `deposits + bonds posted - amounts already withdrawn`. This exactly drains the circle's
+    // funds; unrealized prizes are clawed back. See {abort} docs. Refunding is idempotent (it
+    // zeroes the member's ledger), so an address appearing on both rosters is paid at most once.
+    address token = circle.token;
+    address[] memory members = _members[id];
+    for (uint256 i = 0; i < members.length; i++) {
+      _refund(id, members[i], token);
+    }
+    address[] memory former = _formerMembers[id];
+    for (uint256 i = 0; i < former.length; i++) {
+      _refund(id, former[i], token);
+    }
+
+    emit CircleAborted(id);
+  }
+
+  /// @dev Pay `x` their net principal and zero every balance the contract holds for them, so a
+  ///      second call (e.g. an address on both the active and former rosters) refunds nothing.
+  function _refund(uint256 id, address x, address token) internal {
+    uint256 credit = _deposited[id][x] + _bondPosted[id][x];
+    uint256 debit = _withdrawn[id][x];
+    uint256 refund = credit > debit ? credit - debit : 0;
+
+    _claimable[id][x] = 0;
+    _coll[id][x] = 0;
+    _withheld[id][x] = 0;
+    _bond[id][x] = 0;
+    _deposited[id][x] = 0;
+    _bondPosted[id][x] = 0;
+
+    if (refund == 0) return;
+    _withdrawn[id][x] += refund;
+    IERC20(token).safeTransfer(x, refund);
+    emit Refunded(id, x, refund);
+  }
+
+  // =======================
+  // VIEWS
+  // =======================
+
+  /// @inheritdoc IChitSavingCircles
+  function isTokenAllowed(address token) external view override returns (bool) {
+    return _allowedTokens[token];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function nextId() external view override returns (uint256) {
+    return _nextId;
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function getCircle(uint256 id) external view override returns (Circle memory) {
+    return _existingView(id);
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function getMembers(uint256 id) external view override returns (address[] memory) {
+    _existingView(id);
+    return _members[id];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function circleState(uint256 id) external view override returns (CircleState) {
+    Circle memory circle = _existingView(id);
+    if (_aborted[id]) return CircleState.Aborted;
+    if (circle.startTime == 0) return CircleState.Open;
+    if (_awardedCount[id] >= circle.numSlots) return CircleState.Ended;
+    return CircleState.Active;
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function currentRound(uint256 id) external view override returns (uint256) {
+    return _round(_existingView(id));
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function currentPhase(uint256 id) external view override returns (Phase) {
+    return _phase(_existingView(id));
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function awardedCount(uint256 id) external view override returns (uint256) {
+    _existingView(id);
+    return _awardedCount[id];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function bidCap(uint256 id, uint256 round) external view override returns (uint256) {
+    Circle memory circle = _existingView(id);
+    if (round >= circle.numSlots) return 0;
+    return (circle.numSlots - 1 - round) * circle.depositAmount;
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function collateralOf(uint256 id, address member) external view override returns (uint256) {
+    return _coll[id][member];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function withheldOf(uint256 id, address member) external view override returns (uint256) {
+    return _withheld[id][member];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function bondOf(uint256 id, address member) external view override returns (uint256) {
+    return _bond[id][member];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function claimableOf(uint256 id, address member) external view override returns (uint256) {
+    return _claimable[id][member];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function residualOf(uint256 id, address member) external view override returns (uint256) {
+    return _remaining[id][member] * _circles[id].depositAmount;
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function isPrized(uint256 id, address member) external view override returns (bool) {
+    return _prized[id][member];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function isDefaulted(uint256 id, address member) external view override returns (bool) {
+    return _defaulted[id][member];
+  }
+
+  /// @inheritdoc IChitSavingCircles
+  function isAwardable(uint256 id) external view override returns (bool) {
+    Circle memory circle = _existingView(id);
+    uint256 f = _awardedCount[id];
+    if (_aborted[id] || f >= circle.numSlots || _round(circle) <= f) return false;
+    return _awardableCore(id, f, circle.depositAmount);
+  }
+
+  // =======================
+  // INTERNAL
+  // =======================
+
+  /// @dev Whether round `f` (assumed closed) can be settled: every non-depositor is coverable and
+  ///      at least one eligible member remains to receive the pot.
+  function _awardableCore(uint256 id, uint256 f, uint256 m) internal view returns (bool) {
+    address[] memory members = _members[id];
+    bool hasWinner;
+    for (uint256 i = 0; i < members.length; i++) {
+      address x = members[i];
+      bool current = _roundDeposit[id][f][x] >= m;
+      if (!current && !_prized[id][x] && _bond[id][x] < m) return false; // uncoverable non-prized miss
+      if (current && !_prized[id][x] && !_defaulted[id][x]) hasWinner = true;
+    }
+    return hasWinner;
+  }
+
+  function _round(Circle memory circle) internal view returns (uint256) {
+    if (circle.startTime == 0 || block.timestamp < circle.startTime) return 0;
+    return (block.timestamp - circle.startTime) / circle.roundDuration;
+  }
+
+  function _phase(Circle memory circle) internal view returns (Phase) {
+    if (circle.startTime == 0 || block.timestamp < circle.startTime) return Phase.Commit;
+    uint256 into = (block.timestamp - circle.startTime) % circle.roundDuration;
+    return into < circle.roundDuration - circle.revealDuration ? Phase.Commit : Phase.Reveal;
+  }
+
+  function _existing(uint256 id) internal view returns (Circle storage circle) {
+    circle = _circles[id];
+    if (circle.token == address(0)) revert CircleNotFound();
+  }
+
+  function _existingView(uint256 id) internal view returns (Circle memory circle) {
+    circle = _circles[id];
+    if (circle.token == address(0)) revert CircleNotFound();
+  }
+}

--- a/src/interfaces/IChitSavingCircles.sol
+++ b/src/interfaces/IChitSavingCircles.sol
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @title IChitSavingCircles — Variant D, "the foremanless chit"
+ * @notice Interface for a permissionless, capital-efficient rotating savings and credit
+ *         association (ROSCA) that allocates each round's pot by a sealed-bid reverse auction
+ *         and secures it with prize-time, two-tier collateral.
+ * @dev This is the "Variant D" design of docs/collateralized-permissionless-circles.md, the
+ *      on-chain compilation of the Indian chit fund (Chit Funds Act, 1982). It removes the
+ *      baseline {ISavingCircles} trust bound *and* the ~4x over-collateralization of the
+ *      fixed-rotation collateral variants, while paying patient members an endogenous interest
+ *      rate. A circle runs a single cycle of `numSlots` rounds; every member deposits the
+ *      per-round amount `m` every round, and exactly one member is *prized* (wins the pot) per
+ *      round, so after `n` rounds everyone has won once.
+ *
+ *      ## The mechanism, in one screen
+ *
+ *      Each round `j` (0-indexed) proceeds in two phases inside the round window:
+ *        1. *Commit* — members deposit `m` and submit a sealed bid `H(discount, salt)`.
+ *        2. *Reveal* — members reveal `(discount, salt)`; the highest revealed discount wins.
+ *      After the round closes, anyone calls {award} to settle it (rounds settle strictly in
+ *      order). Sealed bids make the auction robust to an adversarial block scheduler: an
+ *      open-outcry on-chain auction would hand the sequencer a last-look (censor rivals, snipe
+ *      with `d+epsilon`). If nobody bids, the round falls back to fixed rotation (`d = 0`),
+ *      so a rotation ROSCA is D's degenerate case.
+ *
+ *      ## Prize-time two-tier security (the safety core, "Theorem D3")
+ *
+ *      Only a member who has *already won* can steal — she has taken the pot and still owes her
+ *      remaining `(n-1-j)*m` of deposits. So collateral is demanded *only at prize time* and
+ *      *only for the exact residual*. At award the winner's bid `d` is **withheld as first-loss
+ *      security** rather than paid out, and she locks the remainder in cash:
+ *
+ *          withheld = d           coll = (n-1-j)*m - d           withheld + coll = residual
+ *
+ *      A bigger bid means a smaller cash lock; you can never bid away more than you owe
+ *      (`d <= (n-1-j)*m`). The invariant `withheld + coll == residual` is preserved every round
+ *      (both fall by `m` per settled deposit), so every future pot is made whole against *any*
+ *      set of prized defaulters. A would-be thief who bids high merely pre-pays her own
+ *      first-loss cover: her realizable theft is `0` whatever she bids.
+ *
+ *      ## Dividends = endogenous interest ("D6")
+ *
+ *      As a prized member makes each on-time deposit, a slice of her withheld bid is released
+ *      pro-rata to the other members (a credit they can {claim}), and the matching slice of her
+ *      cash lock is returned to her. Over her remaining rounds an honest winner pays out exactly
+ *      her bid `d` — her interest — and recovers her whole cash lock. Patient members who win
+ *      late with low bids are net receivers of interest; impatient early winners pay it.
+ *
+ *      ## Non-prized default and churn
+ *
+ *      A member who has *not* won owes nothing she has not already lent; her default is not a
+ *      credit event, only a coordination one. She posts a one-round membership `bond` of `m` at
+ *      join; a missed deposit is covered from that bond and she is flagged defaulted, freeing
+ *      her slot for permissionless {substitute} — a successor posts a fresh bond and assumes the
+ *      slot (the Act's ss.28-30). If a defaulted slot is never substituted the circle can no
+ *      longer complete a round; anyone may then {abort}, which unwinds every member to net-zero
+ *      on principal (deposits + bond back, unrealized prizes clawed back), so no honest member
+ *      loses. See {abort}.
+ *
+ *      ## Scope of this implementation (v1)
+ *
+ *      This ships the auction, prize-time two-tier security, dividends, prized-default cover,
+ *      no-bid rotation fallback, defaulted-slot substitution, and a net-zero abort valve, on a
+ *      cohort that is fixed at {start}. Same-asset collateral means net credit is `<= 0` (the
+ *      "trilemma" of the spec, Prop. 5.4): this is a commitment-savings + mutual-insurance +
+ *      interest-market device, not a lender. Continuous resize and heterogeneous / surety
+ *      collateral are documented extension points. The auction must NOT be combined with the
+ *      under-collateralized Variant C (adverse selection, spec ss.5.5).
+ */
+interface IChitSavingCircles {
+  /**
+   * @notice Lifecycle state of a circle.
+   * @dev Open = accepting members, not yet started.
+   *      Active = started; the single cycle of `n` rounds is running.
+   *      Ended = all `n` rounds have been awarded; members may reclaim bonds and claim balances.
+   *      Aborted = a defaulted slot stalled the circle; everyone unwound to net-zero on principal.
+   */
+  enum CircleState {
+    Open,
+    Active,
+    Ended,
+    Aborted
+  }
+
+  /**
+   * @notice The commit/reveal phase within the current round.
+   */
+  enum Phase {
+    Commit,
+    Reveal
+  }
+
+  /**
+   * @notice Immutable parameters of a circle.
+   * @param token The ERC20 token used for deposits, collateral, bonds and payouts.
+   * @param depositAmount The per-round deposit amount `m`.
+   * @param numSlots The number of member slots `n`; also the number of rounds in the cycle.
+   * @param roundDuration The duration of a single round, in seconds.
+   * @param revealDuration The length of the reveal phase at the end of each round, in seconds
+   *        (`0 < revealDuration < roundDuration`). The commit/deposit phase is the remainder.
+   * @param startTime The timestamp at which the circle started (0 until started).
+   */
+  struct Circle {
+    address token;
+    uint256 depositAmount;
+    uint256 numSlots;
+    uint256 roundDuration;
+    uint256 revealDuration;
+    uint256 startTime;
+  }
+
+  // =======================
+  // EVENTS
+  // =======================
+
+  /// @notice Emitted when a token is allowed or disallowed by the admin.
+  event TokenAllowed(address indexed token, bool indexed allowed);
+
+  /// @notice Emitted when a new circle is created.
+  event CircleCreated(
+    uint256 indexed id,
+    address indexed token,
+    uint256 depositAmount,
+    uint256 numSlots,
+    uint256 roundDuration,
+    uint256 revealDuration
+  );
+
+  /// @notice Emitted when a member claims a slot in a circle (via {join} or {substitute}).
+  event MemberJoined(uint256 indexed id, address indexed member, uint256 slot);
+
+  /// @notice Emitted when a circle starts (all slots filled).
+  event CircleStarted(uint256 indexed id, uint256 startTime);
+
+  /// @notice Emitted when a member deposits into a round.
+  event Deposited(uint256 indexed id, address indexed member, uint256 round, uint256 amount);
+
+  /// @notice Emitted when a member submits a sealed bid commitment for a round.
+  event BidCommitted(uint256 indexed id, address indexed member, uint256 round);
+
+  /// @notice Emitted when a member reveals their bid for a round.
+  event BidRevealed(uint256 indexed id, address indexed member, uint256 round, uint256 discount);
+
+  /**
+   * @notice Emitted when a round's pot is awarded.
+   * @param winner The prized member.
+   * @param round The round index.
+   * @param discount The winning bid, withheld as first-loss security.
+   * @param cash The immediate cash paid to the winner's claimable balance (`(round+1)*m`).
+   * @param collateral The winner's cash lock (`residual - discount`).
+   */
+  event Awarded(
+    uint256 indexed id, address indexed winner, uint256 round, uint256 discount, uint256 cash, uint256 collateral
+  );
+
+  /// @notice Emitted when a prized member's missed deposit is covered from her own security.
+  event Covered(uint256 indexed id, address indexed member, uint256 round, uint256 amount);
+
+  /// @notice Emitted when a non-prized member's missed deposit is covered from her bond.
+  event BondCovered(uint256 indexed id, address indexed member, uint256 round, uint256 amount);
+
+  /// @notice Emitted when a member is flagged defaulted (her bond was consumed by a cover).
+  event MemberDefaulted(uint256 indexed id, address indexed member);
+
+  /**
+   * @notice Emitted when a prized member's on-time deposit releases part of her security.
+   * @param collReturned The cash lock returned to the member.
+   * @param dividend The withheld slice distributed to the other members as interest.
+   */
+  event SecurityReleased(
+    uint256 indexed id, address indexed member, uint256 round, uint256 collReturned, uint256 dividend
+  );
+
+  /// @notice Emitted when a defaulted slot is taken over by a successor.
+  event MemberSubstituted(uint256 indexed id, address indexed oldMember, address indexed newMember, uint256 slot);
+
+  /// @notice Emitted when a member withdraws their claimable balance.
+  event Claimed(uint256 indexed id, address indexed member, uint256 amount);
+
+  /// @notice Emitted when a member reclaims their membership bond after the circle ends.
+  event BondReclaimed(uint256 indexed id, address indexed member, uint256 amount);
+
+  /// @notice Emitted when a stalled circle is aborted and unwound.
+  event CircleAborted(uint256 indexed id);
+
+  /// @notice Emitted for each member's net-zero refund during an abort.
+  event Refunded(uint256 indexed id, address indexed member, uint256 amount);
+
+  // =======================
+  // ERRORS
+  // =======================
+
+  /// @notice Thrown when the token is not on the allow-list.
+  error TokenNotAllowed();
+  /// @notice Thrown when a circle parameter is invalid.
+  error InvalidParameters();
+  /// @notice Thrown when acting on a circle id that does not exist.
+  error CircleNotFound();
+  /// @notice Thrown when joining a circle that is full or already started.
+  error CircleNotOpen();
+  /// @notice Thrown when the caller is already a member.
+  error AlreadyMember();
+  /// @notice Thrown when the subject is not a member.
+  error NotMember();
+  /// @notice Thrown when starting a circle that is not yet full.
+  error CircleNotFull();
+  /// @notice Thrown when acting on a circle in the wrong lifecycle state.
+  error WrongState();
+  /// @notice Thrown when committing/revealing in the wrong phase of the round.
+  error WrongPhase();
+  /// @notice Thrown when a deposit would exceed the per-round amount `m`.
+  error ExceedsDepositAmount();
+  /// @notice Thrown when a bidder is not current (has not fully deposited the round).
+  error NotCurrent();
+  /// @notice Thrown when a member has already committed a bid for the round.
+  error AlreadyCommitted();
+  /// @notice Thrown when revealing without a matching commitment.
+  error InvalidReveal();
+  /// @notice Thrown when a member who has already won attempts to bid.
+  error AlreadyPrized();
+  /// @notice Thrown when a defaulted member attempts to act where disallowed.
+  error MemberIsDefaulted();
+  /// @notice Thrown when a bid exceeds the residual cap `(n-1-round)*m`.
+  error BidTooHigh();
+  /// @notice Thrown when awarding a round whose window has not closed yet.
+  error RoundNotClosed();
+  /// @notice Thrown when a round cannot be made whole (a defaulted slot with no substitute).
+  error NotAwardable();
+  /// @notice Thrown when no eligible member remains to receive a round's pot.
+  error NoEligibleWinner();
+  /// @notice Thrown when aborting a circle that is not actually stalled.
+  error NotStuck();
+  /// @notice Thrown when there is nothing to claim or reclaim.
+  error NothingToClaim();
+  /// @notice Thrown when substituting a slot that is not a defaulted, non-prized member.
+  error NotSubstitutable();
+
+  // =======================
+  // ADMIN
+  // =======================
+
+  /**
+   * @notice Initialize the upgradeable contract.
+   * @param owner The admin that manages the token allow-list.
+   */
+  function initialize(address owner) external;
+
+  /**
+   * @notice Allow or disallow a token for use in circles.
+   * @param token The token address.
+   * @param allowed Whether the token is allowed.
+   */
+  function setTokenAllowed(address token, bool allowed) external;
+
+  // =======================
+  // CIRCLE LIFECYCLE
+  // =======================
+
+  /**
+   * @notice Permissionlessly create a new circle. The caller does not become a member.
+   * @param token The ERC20 token (must be allowed).
+   * @param depositAmount The per-round deposit `m` (> 0).
+   * @param numSlots The number of slots `n` (>= 2).
+   * @param roundDuration The round duration in seconds (> 0).
+   * @param revealDuration The reveal-phase length in seconds (`0 < revealDuration < roundDuration`).
+   * @return id The id of the new circle.
+   */
+  function createCircle(
+    address token,
+    uint256 depositAmount,
+    uint256 numSlots,
+    uint256 roundDuration,
+    uint256 revealDuration
+  ) external returns (uint256 id);
+
+  /**
+   * @notice Permissionlessly join an open circle, taking the next free slot, posting the
+   *         one-round membership bond `m`.
+   * @param id The circle id.
+   */
+  function join(uint256 id) external;
+
+  /**
+   * @notice Permissionlessly start a circle once all slots are filled.
+   * @param id The circle id.
+   */
+  function start(uint256 id) external;
+
+  /**
+   * @notice Deposit for the caller into the current round.
+   * @param id The circle id.
+   * @param value The amount to deposit (partial deposits accumulate toward `m`).
+   */
+  function deposit(uint256 id, uint256 value) external;
+
+  /**
+   * @notice Deposit for another member into the current round (funded by the caller).
+   * @param id The circle id.
+   * @param member The member to credit.
+   * @param value The amount to deposit.
+   */
+  function depositFor(uint256 id, address member, uint256 value) external;
+
+  /**
+   * @notice Submit a sealed bid for the current round during its commit phase.
+   * @dev `commitment` MUST equal `keccak256(abi.encode(discount, salt, msg.sender, id, round))`.
+   *      The caller must be a non-prized, non-defaulted member who has fully deposited the round.
+   * @param id The circle id.
+   * @param commitment The sealed bid hash.
+   */
+  function commitBid(uint256 id, bytes32 commitment) external;
+
+  /**
+   * @notice Reveal a previously committed bid during the current round's reveal phase.
+   * @param id The circle id.
+   * @param discount The bid discount `d`, capped at the residual `(n-1-round)*m`.
+   * @param salt The salt used in the commitment.
+   */
+  function revealBid(uint256 id, uint256 discount, bytes32 salt) external;
+
+  /**
+   * @notice Settle the next unawarded round (its window must have closed). Callable by anyone.
+   * @dev Rounds settle strictly in order. Completes the pot by covering non-depositors from
+   *      their own security (prized) or bond (non-prized), allocates the pot to the winning
+   *      bidder (or the rotation fallback), sets the winner's two-tier security, and releases
+   *      matured security of earlier winners as dividends.
+   * @param id The circle id.
+   */
+  function award(uint256 id) external;
+
+  /**
+   * @notice Withdraw the caller's accrued claimable balance (prize cash, returned collateral,
+   *         and dividends).
+   * @param id The circle id.
+   */
+  function claim(uint256 id) external;
+
+  /**
+   * @notice Take over a defaulted, non-prized member's slot, posting a fresh membership bond.
+   * @dev This is the chit's ss.28-30 substitution: the successor assumes the slot and its future
+   *      deposit schedule and prize eligibility; the defaulter's forfeited stake keeps the past
+   *      pots whole, so no other member is affected.
+   * @param id The circle id.
+   * @param oldMember The defaulted member to replace.
+   */
+  function substitute(uint256 id, address oldMember) external;
+
+  /**
+   * @notice Reclaim the caller's membership bond once the circle has ended.
+   * @param id The circle id.
+   */
+  function reclaimBond(uint256 id) external;
+
+  /**
+   * @notice Abort a circle that can no longer complete a round (a defaulted slot with no
+   *         substitute), refunding every member to net-zero on principal.
+   * @dev Callable by anyone, only when stalled. Each member receives
+   *      `deposits + bondsPosted - amountsWithdrawn` (>= 0); unrealized prizes are clawed back.
+   *      Because every prized member's remaining obligation is fully secured (`withheld + coll ==
+   *      residual`), this exactly drains the circle's funds and no honest member loses principal.
+   * @param id The circle id.
+   */
+  function abort(uint256 id) external;
+
+  // =======================
+  // VIEWS
+  // =======================
+
+  /// @notice Returns whether a token is allowed.
+  function isTokenAllowed(address token) external view returns (bool allowed);
+
+  /// @notice Returns the id that will be assigned to the next created circle.
+  function nextId() external view returns (uint256 id);
+
+  /// @notice Returns the immutable parameters of a circle.
+  function getCircle(uint256 id) external view returns (Circle memory circle);
+
+  /// @notice Returns the ordered members (by slot) of a circle.
+  function getMembers(uint256 id) external view returns (address[] memory members);
+
+  /// @notice Returns the current lifecycle state of a circle.
+  function circleState(uint256 id) external view returns (CircleState state);
+
+  /// @notice Returns the current round index (0-based); may exceed `numSlots` once the cycle ends.
+  function currentRound(uint256 id) external view returns (uint256 round);
+
+  /// @notice Returns the commit/reveal phase of the current round.
+  function currentPhase(uint256 id) external view returns (Phase phase);
+
+  /// @notice Returns the index of the next round awaiting award (equals the count already awarded).
+  function awardedCount(uint256 id) external view returns (uint256 count);
+
+  /// @notice Returns the residual cap on a bid for `round`, i.e. `(numSlots - 1 - round) * m`.
+  function bidCap(uint256 id, uint256 round) external view returns (uint256 cap);
+
+  /// @notice Returns a member's remaining cash collateral lock.
+  function collateralOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /// @notice Returns a member's remaining withheld bid (first-loss security).
+  function withheldOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /// @notice Returns a member's remaining membership bond.
+  function bondOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /// @notice Returns a member's claimable balance (prize cash + returned collateral + dividends).
+  function claimableOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /// @notice Returns a member's outstanding deposit obligation for the rest of the cycle.
+  function residualOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /// @notice Returns whether a member has already won (is prized).
+  function isPrized(uint256 id, address member) external view returns (bool prized);
+
+  /// @notice Returns whether a member is flagged defaulted.
+  function isDefaulted(uint256 id, address member) external view returns (bool defaulted);
+
+  /// @notice Returns whether the next unawarded round can currently be made whole.
+  function isAwardable(uint256 id) external view returns (bool awardable);
+}

--- a/test/unit/ChitSavingCirclesUnit.t.sol
+++ b/test/unit/ChitSavingCirclesUnit.t.sol
@@ -1,0 +1,570 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {Test} from 'forge-std/Test.sol';
+
+import {ChitSavingCircles} from 'src/contracts/ChitSavingCircles.sol';
+import {IChitSavingCircles} from 'src/interfaces/IChitSavingCircles.sol';
+import {MockERC20} from 'test/mocks/MockERC20.sol';
+
+/**
+ * @notice Unit tests for {ChitSavingCircles} (Variant D — the foremanless chit).
+ * @dev Scenario constants: n = 3 slots, m = 1e18 per round, round = 1 day, reveal = last 6h.
+ *      Slots: alice = 0, bob = 1, carol = 2 (dave is a spare for substitution).
+ *      Each round: deposit + commit in the first 18h, reveal in the last 6h, then {award}
+ *      after the round closes. Rounds settle strictly in order.
+ */
+contract ChitSavingCirclesUnit is Test {
+  ChitSavingCircles public circles;
+  MockERC20 public token;
+
+  address public owner = makeAddr('owner');
+  address public stranger = makeAddr('stranger');
+  address public alice = makeAddr('alice');
+  address public bob = makeAddr('bob');
+  address public carol = makeAddr('carol');
+  address public dave = makeAddr('dave');
+  address public eve = makeAddr('eve');
+
+  uint256 public constant M = 1e18; // per-round deposit
+  uint256 public constant N = 3; // slots
+  uint256 public constant RD = 1 days; // round duration
+  uint256 public constant REVEAL = 6 hours; // reveal phase length
+  uint256 public constant POT = N * M; // 3e18
+  uint256 public constant START_BAL = 100e18;
+
+  bytes32 public constant SALT = keccak256('salt');
+
+  uint256 public id;
+  uint256 public start;
+
+  function setUp() public {
+    vm.startPrank(owner);
+    circles = ChitSavingCircles(
+      address(
+        new TransparentUpgradeableProxy(
+          address(new ChitSavingCircles()),
+          address(new ProxyAdmin(owner)),
+          abi.encodeWithSelector(ChitSavingCircles.initialize.selector, owner)
+        )
+      )
+    );
+    token = new MockERC20('Test', 'TST');
+    circles.setTokenAllowed(address(token), true);
+    vm.stopPrank();
+
+    address[5] memory ms = [alice, bob, carol, dave, eve];
+    for (uint256 i = 0; i < ms.length; i++) {
+      token.mint(ms[i], START_BAL);
+      vm.prank(ms[i]);
+      token.approve(address(circles), type(uint256).max);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  /// @dev A stranger creates the circle, alice/bob/carol join and it is started.
+  function _createAndStart() internal {
+    vm.prank(stranger);
+    id = circles.createCircle(address(token), M, N, RD, REVEAL);
+
+    vm.prank(alice);
+    circles.join(id);
+    vm.prank(bob);
+    circles.join(id);
+    vm.prank(carol);
+    circles.join(id);
+
+    vm.prank(stranger);
+    circles.start(id);
+    start = circles.getCircle(id).startTime;
+  }
+
+  function _commitPhase(uint256 r) internal {
+    vm.warp(start + r * RD + 1);
+  }
+
+  function _revealPhase(uint256 r) internal {
+    vm.warp(start + r * RD + (RD - REVEAL) + 1);
+  }
+
+  function _close(uint256 r) internal {
+    vm.warp(start + (r + 1) * RD + 1);
+  }
+
+  function _deposit(address who) internal {
+    vm.prank(who);
+    circles.deposit(id, M);
+  }
+
+  function _commit(address who, uint256 r, uint256 d) internal {
+    bytes32 h = keccak256(abi.encode(d, SALT, who, id, r));
+    vm.prank(who);
+    circles.commitBid(id, h);
+  }
+
+  function _reveal(address who, uint256 d) internal {
+    vm.prank(who);
+    circles.revealBid(id, d, SALT);
+  }
+
+  /// @dev Sum of everything the contract still owes members; must equal its token balance.
+  function _heldFor(address who) internal view returns (uint256) {
+    return circles.claimableOf(id, who) + circles.collateralOf(id, who) + circles.withheldOf(id, who)
+      + circles.bondOf(id, who);
+  }
+
+  function _assertConserved() internal view {
+    uint256 held = _heldFor(alice) + _heldFor(bob) + _heldFor(carol) + _heldFor(dave);
+    // Plus any deposits sitting in a not-yet-awarded round pot are already inside the contract;
+    // this coarse check asserts the contract never holds less than it owes as security/claims.
+    assertGe(token.balanceOf(address(circles)), held, 'contract cannot back its obligations');
+  }
+
+  // ==========================================================================
+  // Happy path — pure rotation (no bids), everyone ends net-zero
+  // ==========================================================================
+
+  function test_HappyPath_RotationNoBids_NetZeroForAll() public {
+    _createAndStart();
+
+    for (uint256 r = 0; r < N; r++) {
+      _commitPhase(r);
+      _deposit(alice);
+      _deposit(bob);
+      _deposit(carol);
+      _close(r);
+      circles.award(id); // no bids → rotation: slot r wins round r
+
+      // The round-r winner is the slot-r member; its exact residual is locked as coll.
+      address winner = circles.getMembers(id)[r];
+      assertTrue(circles.isPrized(id, winner), 'winner prized');
+      assertEq(
+        circles.collateralOf(id, winner) + circles.withheldOf(id, winner), (N - 1 - r) * M, 'two-tier == residual'
+      );
+      _assertConserved();
+    }
+
+    assertTrue(circles.circleState(id) == IChitSavingCircles.CircleState.Ended);
+
+    // Everyone claims prize + released collateral and reclaims their bond → back to start.
+    address[3] memory ms = [alice, bob, carol];
+    for (uint256 i = 0; i < ms.length; i++) {
+      assertEq(circles.claimableOf(id, ms[i]), POT, 'each got a whole pot back over the cycle');
+      vm.startPrank(ms[i]);
+      circles.claim(id);
+      circles.reclaimBond(id);
+      vm.stopPrank();
+      assertEq(token.balanceOf(ms[i]), START_BAL, 'net zero');
+    }
+    assertEq(token.balanceOf(address(circles)), 0, 'contract drained');
+  }
+
+  function test_MinimalCircle_TwoMembers_FullLifecycleDrains() public {
+    // n == MINIMUM_SLOTS exercises the division edges (dividend split by n-1 == 1, last-round
+    // residual == 0).
+    vm.prank(stranger);
+    id = circles.createCircle(address(token), M, 2, RD, REVEAL);
+    vm.prank(alice);
+    circles.join(id);
+    vm.prank(bob);
+    circles.join(id);
+    vm.prank(stranger);
+    circles.start(id);
+    start = circles.getCircle(id).startTime;
+
+    for (uint256 r = 0; r < 2; r++) {
+      _commitPhase(r);
+      _deposit(alice);
+      _deposit(bob);
+      _close(r);
+      circles.award(id);
+    }
+
+    assertTrue(circles.circleState(id) == IChitSavingCircles.CircleState.Ended);
+    address[2] memory ms = [alice, bob];
+    for (uint256 i = 0; i < ms.length; i++) {
+      vm.startPrank(ms[i]);
+      circles.claim(id);
+      circles.reclaimBond(id);
+      vm.stopPrank();
+      assertEq(token.balanceOf(ms[i]), START_BAL, 'net zero');
+    }
+    assertEq(token.balanceOf(address(circles)), 0, 'contract drained');
+  }
+
+  // ==========================================================================
+  // Auction + dividends — the winning bid is paid out as interest to the rest
+  // ==========================================================================
+
+  function test_Auction_BidBecomesDividendInterest() public {
+    _createAndStart();
+
+    // Round 0: alice bids the whole residual (2m); bob/carol do not bid. alice wins.
+    _commitPhase(0);
+    _deposit(alice);
+    _deposit(bob);
+    _deposit(carol);
+    _commit(alice, 0, 2 * M);
+    _revealPhase(0);
+    _reveal(alice, 2 * M);
+    _close(0);
+    circles.award(id);
+
+    assertTrue(circles.isPrized(id, alice), 'alice won');
+    assertEq(circles.withheldOf(id, alice), 2 * M, 'entire bid withheld as first-loss');
+    assertEq(circles.collateralOf(id, alice), 0, 'a max bid needs zero cash lock');
+    assertEq(circles.residualOf(id, alice), 2 * M, 'residual == withheld + coll');
+
+    // Rounds 1 & 2: rotation (bob then carol). alice keeps depositing, paying out her bid as
+    // dividends. bob/carol split alice's 2m bid equally over the two releases → 1m each.
+    for (uint256 r = 1; r < N; r++) {
+      _commitPhase(r);
+      _deposit(alice);
+      _deposit(bob);
+      _deposit(carol);
+      _close(r);
+      circles.award(id);
+      _assertConserved();
+    }
+
+    // Settle everyone.
+    address[3] memory ms = [alice, bob, carol];
+    for (uint256 i = 0; i < ms.length; i++) {
+      vm.startPrank(ms[i]);
+      circles.claim(id);
+      circles.reclaimBond(id);
+      vm.stopPrank();
+    }
+
+    // alice paid 2m of interest; bob and carol earned 1m each. Interest is zero-sum.
+    assertEq(token.balanceOf(alice), START_BAL - 2 * M, 'impatient bidder pays interest');
+    assertEq(token.balanceOf(bob), START_BAL + M, 'patient member earns interest');
+    assertEq(token.balanceOf(carol), START_BAL + M, 'patient member earns interest');
+    assertEq(token.balanceOf(address(circles)), 0, 'contract drained');
+  }
+
+  // ==========================================================================
+  // D3 — a prized member who bids high and then defaults steals nothing
+  // ==========================================================================
+
+  function test_PrizedDefault_TheftIsZero_HonestMembersWhole() public {
+    _createAndStart();
+
+    // Round 0: alice bids the max (2m) and wins, then never deposits again.
+    _commitPhase(0);
+    _deposit(alice);
+    _deposit(bob);
+    _deposit(carol);
+    _commit(alice, 0, 2 * M);
+    _revealPhase(0);
+    _reveal(alice, 2 * M);
+    _close(0);
+    circles.award(id);
+    assertEq(circles.withheldOf(id, alice), 2 * M);
+
+    // Rounds 1 & 2: alice defaults on every deposit; bob and carol pay honestly.
+    for (uint256 r = 1; r < N; r++) {
+      _commitPhase(r);
+      _deposit(bob);
+      _deposit(carol);
+      // alice deposits nothing
+      _close(r);
+      circles.award(id); // alice's miss is covered from her own withheld first-loss
+      _assertConserved();
+    }
+
+    // alice's security was entirely consumed covering her own defaults.
+    assertEq(circles.withheldOf(id, alice), 0, 'withheld drained by self-cover');
+    assertEq(circles.collateralOf(id, alice), 0, 'no cash lock left');
+
+    // Every winner still received a full pot; honest members lose nothing.
+    address[3] memory ms = [alice, bob, carol];
+    for (uint256 i = 0; i < ms.length; i++) {
+      if (circles.claimableOf(id, ms[i]) > 0) {
+        vm.prank(ms[i]);
+        circles.claim(id);
+      }
+      vm.prank(ms[i]);
+      circles.reclaimBond(id);
+    }
+
+    // alice took her 1m prize (== her single deposit) and forfeited nothing extra → net zero.
+    assertEq(token.balanceOf(alice), START_BAL, 'defaulter net zero: theft is zero');
+    // bob and carol received full pots and are whole (no bids placed by them → no interest here).
+    assertEq(token.balanceOf(bob), START_BAL, 'honest member whole');
+    assertEq(token.balanceOf(carol), START_BAL, 'honest member whole');
+    assertEq(token.balanceOf(address(circles)), 0, 'contract drained');
+  }
+
+  // ==========================================================================
+  // Substitution — a defaulted non-prized slot is taken over, circle completes
+  // ==========================================================================
+
+  function test_Substitution_DefaultedSlotTakenOver_CircleCompletes() public {
+    _createAndStart();
+
+    // Round 0: carol (slot 2) never deposits → covered from her bond, flagged defaulted.
+    _commitPhase(0);
+    _deposit(alice);
+    _deposit(bob);
+    _close(0);
+    circles.award(id); // rotation → alice (slot 0) wins; carol defaulted
+    assertTrue(circles.isDefaulted(id, carol), 'carol defaulted');
+
+    // dave permissionlessly substitutes into carol's slot, posting a fresh bond.
+    vm.prank(dave);
+    circles.substitute(id, carol);
+    assertEq(circles.getMembers(id)[2], dave, 'dave took slot 2');
+    assertFalse(circles.isDefaulted(id, dave));
+
+    // Rounds 1 & 2 proceed with dave in the cohort; bob then dave win.
+    for (uint256 r = 1; r < N; r++) {
+      _commitPhase(r);
+      _deposit(alice);
+      _deposit(bob);
+      _deposit(dave);
+      _close(r);
+      circles.award(id);
+    }
+
+    assertTrue(circles.circleState(id) == IChitSavingCircles.CircleState.Ended, 'circle completed');
+
+    // Honest alice and bob are made whole; the defaulter carol forfeited only her own bond.
+    address[3] memory finishers = [alice, bob, dave];
+    for (uint256 i = 0; i < finishers.length; i++) {
+      vm.startPrank(finishers[i]);
+      circles.claim(id);
+      circles.reclaimBond(id);
+      vm.stopPrank();
+    }
+    assertEq(token.balanceOf(alice), START_BAL, 'alice whole');
+    assertEq(token.balanceOf(bob), START_BAL, 'bob whole');
+    assertEq(token.balanceOf(carol), START_BAL - M, 'defaulter forfeits exactly her bond');
+    assertEq(token.balanceOf(address(circles)), 0, 'contract drained');
+  }
+
+  // ==========================================================================
+  // Abort — an un-substituted default stalls the circle; everyone unwinds net-zero
+  // ==========================================================================
+
+  function test_Abort_StalledCircle_UnwindsEveryoneToNetZero() public {
+    _createAndStart();
+
+    // Round 0: carol defaults (covered from bond), alice wins.
+    _commitPhase(0);
+    _deposit(alice);
+    _deposit(bob);
+    _close(0);
+    circles.award(id);
+    assertTrue(circles.isDefaulted(id, carol));
+
+    // Round 1: nobody substitutes carol; alice and bob deposit, carol cannot be covered again.
+    _commitPhase(1);
+    _deposit(alice);
+    _deposit(bob);
+    _close(1);
+    assertFalse(circles.isAwardable(id), 'round 1 cannot be made whole');
+    vm.expectRevert(IChitSavingCircles.NotAwardable.selector);
+    circles.award(id);
+
+    // Anyone aborts; the net-zero unwind returns every member to their starting balance.
+    vm.prank(stranger);
+    circles.abort(id);
+
+    assertTrue(circles.circleState(id) == IChitSavingCircles.CircleState.Aborted);
+    assertEq(token.balanceOf(alice), START_BAL, 'alice net zero');
+    assertEq(token.balanceOf(bob), START_BAL, 'bob net zero');
+    assertEq(token.balanceOf(carol), START_BAL, 'carol net zero');
+    assertEq(token.balanceOf(address(circles)), 0, 'contract drained');
+  }
+
+  function test_CannotAbortAHealthyCircle() public {
+    _createAndStart();
+    _commitPhase(0);
+    _deposit(alice);
+    _deposit(bob);
+    _deposit(carol);
+    _close(0);
+    vm.prank(stranger);
+    vm.expectRevert(IChitSavingCircles.NotStuck.selector);
+    circles.abort(id);
+  }
+
+  /// @dev Regression: a member substituted out before the circle stalls must still be refunded on
+  ///      abort, or their forfeited bond is stranded and the contract cannot fully drain.
+  function test_Abort_AfterSubstitution_DrainsToZero() public {
+    // 4-member circle: dave defaults and is substituted by eve, who then also defaults with no
+    // successor, stalling the circle.
+    vm.prank(stranger);
+    id = circles.createCircle(address(token), M, 4, RD, REVEAL);
+    address[4] memory core = [alice, bob, carol, dave];
+    for (uint256 i = 0; i < core.length; i++) {
+      vm.prank(core[i]);
+      circles.join(id);
+    }
+    vm.prank(stranger);
+    circles.start(id);
+    start = circles.getCircle(id).startTime;
+
+    // Round 0: dave (slot 3) defaults → covered from his bond, flagged defaulted; alice wins.
+    _commitPhase(0);
+    _deposit(alice);
+    _deposit(bob);
+    _deposit(carol);
+    _close(0);
+    circles.award(id);
+    assertTrue(circles.isDefaulted(id, dave), 'dave defaulted');
+
+    // eve substitutes dave, then herself defaults in round 1.
+    vm.prank(eve);
+    circles.substitute(id, dave);
+
+    _commitPhase(1);
+    _deposit(alice);
+    _deposit(bob);
+    _deposit(carol);
+    _close(1);
+    circles.award(id); // bob wins; eve covered from her bond, defaulted
+    assertTrue(circles.isDefaulted(id, eve), 'eve defaulted');
+
+    // Round 2 cannot be completed (eve un-substituted) → stall → abort.
+    _commitPhase(2);
+    _deposit(alice);
+    _deposit(bob);
+    _deposit(carol);
+    _close(2);
+    vm.expectRevert(IChitSavingCircles.NotAwardable.selector);
+    circles.award(id);
+
+    vm.prank(stranger);
+    circles.abort(id);
+
+    // Everyone — including the substituted-out defaulter dave — unwinds to net-zero, and no bond
+    // is stranded: the contract drains completely.
+    assertEq(token.balanceOf(alice), START_BAL, 'alice net zero');
+    assertEq(token.balanceOf(bob), START_BAL, 'bob net zero');
+    assertEq(token.balanceOf(carol), START_BAL, 'carol net zero');
+    assertEq(token.balanceOf(dave), START_BAL, 'substituted-out defaulter refunded');
+    assertEq(token.balanceOf(eve), START_BAL, 'substitute defaulter refunded');
+    assertEq(token.balanceOf(address(circles)), 0, 'contract fully drained');
+  }
+
+  // ==========================================================================
+  // Sealed-bid mechanics & guards
+  // ==========================================================================
+
+  function test_Reveal_MustMatchCommitment() public {
+    _createAndStart();
+    _commitPhase(0);
+    _deposit(alice);
+    _commit(alice, 0, M); // committed to discount = m
+    _revealPhase(0);
+    vm.prank(alice);
+    vm.expectRevert(IChitSavingCircles.InvalidReveal.selector);
+    circles.revealBid(id, 2 * M, SALT); // reveals a different discount
+  }
+
+  function test_Commit_WrongPhaseReverts() public {
+    _createAndStart();
+    _commitPhase(0);
+    _deposit(alice);
+    _revealPhase(0); // now in reveal phase
+    vm.prank(alice);
+    vm.expectRevert(IChitSavingCircles.WrongPhase.selector);
+    circles.commitBid(id, keccak256('x'));
+  }
+
+  function test_Reveal_BidAboveResidualCapReverts() public {
+    _createAndStart();
+    _commitPhase(0);
+    _deposit(alice);
+    _commit(alice, 0, 3 * M); // cap for round 0 is (n-1)*m = 2m
+    _revealPhase(0);
+    vm.prank(alice);
+    vm.expectRevert(IChitSavingCircles.BidTooHigh.selector);
+    circles.revealBid(id, 3 * M, SALT);
+  }
+
+  function test_Reveal_RequiresCurrentDeposit() public {
+    _createAndStart();
+    _commitPhase(0);
+    _commit(alice, 0, M); // committed without depositing
+    _revealPhase(0);
+    vm.prank(alice);
+    vm.expectRevert(IChitSavingCircles.NotCurrent.selector);
+    circles.revealBid(id, M, SALT);
+  }
+
+  function test_Award_RevertsBeforeRoundCloses() public {
+    _createAndStart();
+    _commitPhase(0);
+    _deposit(alice);
+    _deposit(bob);
+    _deposit(carol);
+    // still inside round 0
+    vm.expectRevert(IChitSavingCircles.RoundNotClosed.selector);
+    circles.award(id);
+  }
+
+  // ==========================================================================
+  // Permissionless membership & parameter guards
+  // ==========================================================================
+
+  function test_Permissionless_AnyoneCreatesJoinsStarts() public {
+    _createAndStart();
+    address[] memory ms = circles.getMembers(id);
+    assertEq(ms.length, N);
+    assertEq(ms[0], alice);
+    assertEq(ms[2], carol);
+    assertTrue(circles.circleState(id) == IChitSavingCircles.CircleState.Active);
+    // Each member's bond is posted at join.
+    assertEq(circles.bondOf(id, alice), M);
+  }
+
+  function test_CannotJoinTwice() public {
+    vm.prank(stranger);
+    id = circles.createCircle(address(token), M, N, RD, REVEAL);
+    vm.prank(alice);
+    circles.join(id);
+    vm.prank(alice);
+    vm.expectRevert(IChitSavingCircles.AlreadyMember.selector);
+    circles.join(id);
+  }
+
+  function test_CannotStartUntilFull() public {
+    vm.prank(stranger);
+    id = circles.createCircle(address(token), M, N, RD, REVEAL);
+    vm.prank(alice);
+    circles.join(id);
+    vm.prank(stranger);
+    vm.expectRevert(IChitSavingCircles.CircleNotFull.selector);
+    circles.start(id);
+  }
+
+  function test_RejectsDisallowedToken() public {
+    MockERC20 other = new MockERC20('Other', 'OTH');
+    vm.prank(stranger);
+    vm.expectRevert(IChitSavingCircles.TokenNotAllowed.selector);
+    circles.createCircle(address(other), M, N, RD, REVEAL);
+  }
+
+  function test_RejectsBadParameters() public {
+    vm.startPrank(stranger);
+    vm.expectRevert(IChitSavingCircles.InvalidParameters.selector);
+    circles.createCircle(address(token), 0, N, RD, REVEAL); // zero deposit
+    vm.expectRevert(IChitSavingCircles.InvalidParameters.selector);
+    circles.createCircle(address(token), M, 1, RD, REVEAL); // below MINIMUM_SLOTS
+    vm.expectRevert(IChitSavingCircles.InvalidParameters.selector);
+    circles.createCircle(address(token), M, N, 0, REVEAL); // zero round
+    vm.expectRevert(IChitSavingCircles.InvalidParameters.selector);
+    circles.createCircle(address(token), M, N, RD, 0); // zero reveal window
+    vm.expectRevert(IChitSavingCircles.InvalidParameters.selector);
+    circles.createCircle(address(token), M, N, RD, RD); // reveal >= round
+    vm.stopPrank();
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements **Variant D — "the foremanless chit"**, a permissionless, capital-efficient
reverse-auction rotating savings circle (ROSCA), together with a design document and a full unit-test
suite. It is the on-chain compilation of the Indian chit fund (Chit Funds Act, 1982).

It is the follow-up promised in **[#182](https://github.com/BreadchainCoop/saving-circles/pull/182)**
(Variant A, *collateral-first*): that PR's spec derives four collateralized permissionless designs and
recommends Variant D as the one that **supersedes the rolling-bond Variant B at ~¼ the locked capital**.
This PR builds that contract. It is **standalone** and does not touch `SavingCircles` /
`AutomaticSavingCircles`; it can be reviewed and merged independently of #182.

## The idea

A plain ROSCA is secretly a loan — an early recipient takes the pot and is *trusted* to keep paying —
so the baseline can only guarantee an honest saver recovers `(n − t)·m` against `t` colluders, which is
why it must gate entry with owner-signed invites and freeze the cohort. The collateral variants drive
`t → 0` by making everyone post security, but they over-collateralize: they secure **every** member for
a **whole pot** at all times. The chit fund shows this is ~4× too much, because **only a member who has
already won can steal**, and only for what she still owes.

Variant D acts on that:

- **Sealed-bid reverse auction per round.** Members `deposit(m)` and `commitBid(H(discount, salt))` in
  the commit phase, then `revealBid` in the reveal phase; the highest revealed discount wins. Sealed
  bids make the auction robust to an adversarial block scheduler (an open-outcry on-chain auction hands
  the sequencer a last-look — censor rivals, snipe with `d+ε`). **No bids ⇒ fixed rotation**, so a plain
  rotation ROSCA is D's degenerate case.

- **Prize-time two-tier security (the safety core, "Theorem D3").** Collateral is demanded *only at
  award* and *only for the exact residual* `(n−1−j)·m`. The winner's bid `d` is **withheld as first-loss
  security** and she locks the rest in cash, so the invariant

  ```
  withheld(x) + coll(x) == residual(x)
  ```

  holds at award and is preserved by every rule. Every pot is therefore made whole against **any** set
  of prized defaulters and **no honest member ever loses principal**. A would-be thief who bids high
  merely pre-pays her own first-loss cover — her realizable theft is `0` whatever she bids.

- **Dividends = endogenous interest.** A prized member's withheld bid is released to the other members as
  she makes her on-time deposits; over her residual period an honest winner pays out exactly `d` (her
  interest) and recovers her cash lock. Patient late-winners **earn** interest; impatient early-winners
  pay it (zero-sum).

- **Non-prized default & churn.** A non-prized default is not a credit event; it is covered from a
  one-round membership `bond` of `m` and the slot is freed for permissionless `substitute` (the Act's
  §§28–30). A stalled circle (a defaulted slot with no successor) can be `abort`ed by anyone, unwinding
  every member to **net-zero on principal**.

Capital held tracks the outstanding-credit parabola `K(j)=(j+1)(n−1−j)·m` plus one-round bonds — within
`n·m` of the information-theoretic floor, vs Variant B's ≈ 4× it at peak.

## Contents

- **`src/interfaces/IChitSavingCircles.sol`** — interface; the full mechanism is documented in NatSpec.
- **`src/contracts/ChitSavingCircles.sol`** — upgradeable implementation (Ownable/ReentrancyGuard,
  SafeERC20, admin token allow-list, pull-based `claim`), following repo conventions. Conservation holds
  by construction: value enters only on `deposit`/`join`/`substitute` and leaves only on
  `claim`/`reclaimBond`/`abort`; covers, releases and awards only move value internally.
- **`test/unit/ChitSavingCirclesUnit.t.sol`** — **18 unit tests**: rotation happy-path (net-zero for all),
  auction dividends as zero-sum interest, **D3** (bid the max then default on everything → every recipient
  still whole, defaulter nets zero), substitution completing a circle, stalled-circle abort, **abort after
  substitution**, the `n=2` minimum, and the commit/reveal + parameter guards.
- **`docs/variant-d-foremanless-chit.md`** — design rationale, with the two honest limits from the spec:
  the auction must **not** be combined with under-collateralized Variant C (adverse selection), and the
  same-asset **trilemma** (safety / anonymity / same-asset credit — pick two), which makes this a
  commitment-savings + mutual-insurance + interest-market device rather than a lender.

## Testing

```
forge test --match-contract ChitSavingCirclesUnit   # 18 passed
forge test                                          # 186 passed (full suite)
forge fmt --check … && solhint …                    # clean (0 errors)
```

The implementation was put through an adversarial safety review (independent lenses each trying to break
D3 / conservation / abort solvency / the auction, with findings verified against the code by PoC). It
surfaced one fund-lock bug — `abort` after a `substitute` stranded the substituted-out defaulter's
forfeited bond, because `substitute` removed them from the members array that `abort` iterates — which is
**fixed** in this PR (a historical-roster refund, made idempotent) and covered by the
`test_Abort_AfterSubstitution_DrainsToZero` regression.

## Scope (v1)

Ships the auction, prize-time two-tier security, dividends, prized-default cover, no-bid rotation
fallback, defaulted-slot substitution, and the net-zero abort valve, on a cohort fixed at `start` with
permissionless create / join / start (no owner, no invite). Documented extension points: continuous
mid-cycle resize, voluntary (non-default) substitution with claim transfer, a Vickrey price rule, and
heterogeneous / surety collateral for genuine same-cycle credit.

*Full comparative spec (Variants A–D, proofs, and the chit-fund analysis) is in #182.*
