### PR TITLE
feat: add ASCA, Goal Savings, and Collective Fund stack types

### DIFF
--- a/.github/upgrades.json
+++ b/.github/upgrades.json
@@ -2,7 +2,15 @@
   "contracts": [
     {
       "contract": "src/contracts/SavingCircles.sol:SavingCircles"
+    },
+    {
+      "contract": "src/contracts/AccumulatingSavingCircles.sol:AccumulatingSavingCircles"
+    },
+    {
+      "contract": "src/contracts/GoalSavingCircles.sol:GoalSavingCircles"
+    },
+    {
+      "contract": "src/contracts/CollectiveFundCircles.sol:CollectiveFundCircles"
     }
   ]
 }
-

--- a/docs/accumulating-saving-circles.md
+++ b/docs/accumulating-saving-circles.md
@@ -1,0 +1,102 @@
+# Accumulating Saving Circles (ASCA)
+
+*The "loose" cousin of the ROSCA: flexible savings, a self-collateralized credit line, and
+interest that flows back to the savers — the group banks itself.*
+
+This document is the design rationale for `src/contracts/AccumulatingSavingCircles.sol`. The
+definitive spec (storage layout, exact math, full test plan) lives in the design notes; the
+interface `src/interfaces/IAccumulatingSavingCircles.sol` is the API reference.
+
+---
+
+## 0. What problem it solves
+
+A `SavingCircles` ROSCA forces a fixed deposit on a fixed schedule and pays each member the pot
+exactly once. Many real groups (village associations, co-ops, friend circles) want the *other*
+classic mutual-finance shape instead — the **ASCA** (Accumulating Savings and Credit Association):
+each member puts in **whatever amount they want, whenever they want**, and in exchange earns a
+**credit line equal to a percentage of their own savings**. Loans are repaid within a configured
+number of periods, optionally with simple interest set by the group, and **all interest flows back
+pro-rata to the savers** rather than to a bank.
+
+## 1. The mechanism
+
+- **Singleton registry.** One contract hosts many funds, keyed by `uint256 id`, exactly like
+  `SavingCircles`. The organizer calls `create(token, borrowLimitBps, interestRateBps,
+  repaymentPeriods, periodLength)`, becomes the fund owner and its first member, and invites
+  members with the same EIP-712 `StacksInvite` flow the app already ships (domain
+  `'StacksInvite'/'1'`, typehash `Invite(uint256 id,uint256 nonce)`; only the verifying-contract
+  address differs).
+- **Savings.** `deposit`/`depositFor` add any positive amount to `savings[id][member]`; `withdraw`
+  returns it, subject to the collateral and liquidity guards below. Savings double as
+  MasterChef-style accumulator shares.
+- **Credit.** `borrow(id, amount)` requires `amount * 10_000 <= borrowLimitBps * savings` (the
+  multiplicative form leaves no rounding loophole) and enough `poolCash`. One loan at a time:
+  a second `borrow` reverts with `OutstandingLoan` until the first is fully repaid or liquidated.
+- **Interest.** Simple interest accrues lazily per **whole elapsed period** on outstanding
+  principal (`principal * interestRateBps / 10_000` per period), checkpointed at every touch, and
+  **capped at `repaymentPeriods` periods** — accrual stops at the due date, so the borrower's
+  liability is known at borrow time and can never outgrow deterministic bounds.
+- **Repay waterfall.** `repay` settles accrued interest first, then principal, pulls at most the
+  total debt (overpayment is not taken), and immediately streams the interest received to savers
+  via `accInterestPerShare += interest * 1e18 / totalSavings` (floor; sub-wei dust stays in the
+  pool). Members collect with `claimInterest`.
+- **Liquidation.** Once `block.timestamp >= startTime + repaymentPeriods * periodLength`, anyone
+  may call `liquidate`: it seizes the borrower's savings for the full principal (always covered),
+  plus `min(interestOwed, remaining savings)` which is distributed to savers as interest. It is a
+  **pure ledger reallocation** — no tokens move.
+- **Wind-down.** The organizer's one-way `deactivate` freezes `deposit`/`depositFor`/`borrow`/
+  `redeemInvite` while leaving `withdraw`/`repay`/`claimInterest`/`liquidate` open, so a
+  deactivated fund drains naturally. There is no share-out event; membership is continuous.
+
+## 2. Safety invariants
+
+Let, per fund: `S = totalSavings`, `B = totalBorrowed`, `C = poolCash`, `P = Σ pendingInterestOf`.
+
+- **I1 — internal cash ledger.** All logic reads `poolCash`, never `token.balanceOf`, so donations
+  and other funds sharing the contract cannot corrupt accounting. Every outbound transfer is
+  guarded by `poolCash >= amount`.
+- **I2 — full self-collateralization.** `borrowLimitBps <= 10_000` implies `principal <= savings`
+  for every open loan. Established at `borrow`, preserved by the `withdraw` guard
+  (`(principal + accrued interest) * 10_000 <= borrowLimitBps * remaining savings` — accrued
+  interest counts as debt), and cleared by `liquidate`. Liquidation can therefore always seize the
+  full principal: **a defaulter can only ever burn their own savings, never another member's
+  principal.**
+- **I3 — solvency.** `C + B >= S + P` holds inductively across every operation (distribution and
+  settlement round down, so rounding always favors the pool). Combined with I2, every receivable
+  in `B` is backed by seizable savings, so all liabilities are eventually payable and the
+  liquidity guards are belt-and-suspenders: honest members can always exit within at most
+  `repaymentPeriods * periodLength` via permissionless liquidation.
+- **I4 — value flow.** Tokens enter only via `deposit`/`depositFor`/`repay` and leave only via
+  `withdraw`/`borrow`/`claimInterest`. `liquidate` and `deactivate` move no tokens. Every
+  token-moving external is `nonReentrant` and strictly checks-effects-interactions.
+- **Who can lose what.** A defaulting borrower loses their own savings up to
+  `principal + interestOwed`. Honest savers can lose only *expected future interest* (never
+  credited, never principal) when a defaulter's remaining savings do not cover accrued interest.
+
+## 3. Decisions
+
+- **One loan at a time.** No due-date merges, no per-tranche interest; "loose amounts" is
+  preserved because the member sizes the single borrow freely. Top-ups are a v2 extension.
+- **Interest capped at the due date.** Bounds liability, makes seizure deterministic, and avoids
+  unbounded interest outgrowing collateral; overdue enforcement is permissionless `liquidate`,
+  not compounding.
+- **Borrower's savings stay shares while borrowed.** No freezing bookkeeping; the borrower earning
+  a pro-rata slice of interest (including of their own payments) is standard pool behavior.
+- **Sole-saver liquidation skips interest seizure.** If seizing interest would leave zero shares,
+  there is nobody to distribute it to; burning value to nobody is worse than leaving it as the
+  defaulter's savings. Principal is always seized.
+- **`repay` pulls only `min(amount, debt)`.** Friendlier than reverting; no refund path needed.
+- **Admin ERC20 allowlist as the token control.** Fee-on-transfer, rebasing and ERC777-style
+  tokens are out of scope by policy, exactly the `SavingCircles` pattern.
+
+## 4. Scope (v1) and extensions
+
+Implemented: multi-fund registry, EIP-712 invites, flexible savings, pro-rata interest
+accumulator, single self-collateralized loans, permissionless liquidation, organizer deactivation
+— with branch-complete unit tests in `test/unit/AccumulatingSavingCirclesUnit.t.sol`.
+
+Deferred (documented extension points): loan top-ups / `repayFor`, a Chainlink-automation
+satellite calling `liquidate` on overdue loans, viewer-lens getters, reserving expected interest
+inside the credit line, late fees / grace periods, member removal, protocol fees, and dedicated
+fuzz + invariant suites. The contract is standalone and does not touch `SavingCircles`.

--- a/docs/collective-fund-circles.md
+++ b/docs/collective-fund-circles.md
@@ -1,0 +1,104 @@
+# Collective Fund Circles — the Logos white-label communal fund
+
+*A communal savings pot: deposit anytime, rage-quit anytime for your pro-rata slice, and spend the
+pot together by one-member-one-vote proposals.*
+
+This is the design rationale for `src/contracts/CollectiveFundCircles.sol` /
+`src/interfaces/ICollectiveFundCircles.sol`. The definitive spec lives in
+`.context/design/spec-collective.md`; this note summarizes the mechanism, the math, and the safety
+argument.
+
+---
+
+## 0. What it is
+
+A local community (a Logos cell, a neighborhood group, a co-op) saves into a shared pot and then
+**spends the pot together** — a venue deposit, a food drive, a speaker's travel. Unlike a ROSCA
+there are no rounds, no rotation, no automation and no credit: nobody ever owes anything.
+
+The contract is a singleton registry: many funds per deployment, keyed by `uint256 id`. Each fund
+stores its own on-chain `name`, so a white-label frontend resolves everything from `?f=<id>` with a
+single `getFund(id)` call. Membership uses the exact `StacksInvite` EIP-712 invite flow of
+`SavingCircles` (same domain, same typehash), so the existing app-stacks invite UX ports unchanged.
+Funds are **perpetual** — no start, no decommission; "closing" a fund is everyone withdrawing.
+
+## 1. The mechanism
+
+- **create** (permissionless, allowlisted token): fixes `token`, `votingPeriod`
+  (`0 < x <= 365 days`) and `approvalThresholdBps` (`0 < x <= 10_000`); the `fundOwner` auto-joins
+  at member index 0. The fund owner's only powers are signing invites and renaming the fund.
+- **redeemInvite**: joins with a fund-owner-signed EIP-712 invite, at any time in the fund's life.
+  The member list is **append-only** — no removal in v1 (see §3).
+- **deposit** (member-only): mints shares **1:1** with tokens contributed. Shares are a ledger of
+  contribution, not vault shares ("solidarity accounting", §2).
+- **donate** (anyone): raises the pool without minting shares — gifts to the collective.
+- **withdraw** (rage-quit, anytime): burns shares for
+  `floor(shares * poolBalance / totalShares)`. Never blocked by any proposal state.
+- **propose** (member-only): snapshots `electorate = memberCount` and
+  `requiredYes = ceil(electorate * thresholdBps / 10_000)`; the proposer auto-votes yes. The amount
+  is neither checked against nor reserved from the pool.
+- **vote**: one member one vote, eligible iff `memberIndex < electorate` (the snapshot), open while
+  `now <= createdAt + votingPeriod` and unexecuted.
+- **execute** (anyone): as soon as `yesVotes >= requiredYes` and until
+  `createdAt + 2 * votingPeriod` (a self-scaling grace of one extra voting period), provided
+  `poolBalance >= amount` *at execute time*.
+
+Proposal state is a pure function of storage + time: `Executed`, else `Passed`/`Expired` once the
+threshold is reached (inside/outside the execution window), else `Defeated` after the vote deadline
+or once `electorate - noVotes < requiredYes` (mathematically unreachable), else `Active`.
+
+## 2. The math, and why it rounds the way it does
+
+- **Mint: exact 1:1, always.** After a disbursement (`poolBalance < totalShares`) a *new* deposit
+  still mints 1:1, so a late depositor shares the past dilution equally per contributed token. This
+  is deliberate: everyone who ever contributed X tokens can redeem the same fraction of X,
+  regardless of timing. Frontends must show `previewWithdraw` next to the deposit box.
+- **Withdraw: floor, in favor of the pool.** Rounding dust stays in the pool and accrues to the
+  remaining shareholders; the pool can never be over-drawn. When the last exiter burns
+  `shares == totalShares`, the payout is exactly `poolBalance` — nothing is stranded. Burning
+  zero-value shares when the pool is empty is allowed (share-base reset for future deposits).
+- **Threshold: ceiling, in favor of stricter approval.** "At least thresholdBps of the electorate"
+  cannot be satisfied by fewer heads via flooring; `requiredYes >= 1` always, so no proposal ever
+  passes with zero voices. A single-member fund passes its own proposals at creation (intended:
+  personal pot / demo mode).
+- **Snapshot in O(1).** Because the member list is append-only, "was a member at proposal
+  creation" is exactly `memberIndex < proposal.electorate` — one comparison, no per-proposal
+  eligibility map.
+
+## 3. Safety invariants and decisions
+
+- **I1 share conservation**: `Σ sharesOf == totalShares` per fund (mint in deposit, burn in
+  withdraw — no other mutation, no transfer).
+- **I2 pool conservation**: `poolBalance == deposits + donations − withdrawals − executed amounts`.
+- **I3 singleton solvency**: per token, contract balance `>= Σ poolBalance` across funds — every
+  outflow is debited from exactly one fund and bounded by its pool, so **no fund can spend another
+  fund's tokens**. Direct ERC20 transfers to the contract are not credited and never make a fund
+  insolvent.
+- **I4 single execution**: `executed` flips before the transfer; `execute` is `nonReentrant`.
+- **No reservation, by decision.** A passed proposal does not lock funds: rage-quit freedom is the
+  trust anchor, and a member's deposit is never hostage to a vote they lost. If exits drain the
+  pool below a passed amount, `execute` reverts (`InsufficientPoolBalance`) and the proposal stays
+  `Passed` inside its window — a top-up re-enables it. Reserving would instead let a hostile
+  majority freeze dissenters' exits.
+- **No member removal in v1.** Removal would break the O(1) snapshot; economic exit = withdraw all
+  shares (the vote persists — a curation decision of the fund owner, who controls invites). Listed
+  as the first extension (tombstoned slots).
+- **No defaulter exists.** Nobody owes anything, so no honest member can lose principal to a
+  defaulter — structurally. Redeemable value decreases only via (a) a disbursement the community
+  approved at threshold (the product; the defense is voting no and/or rage-quitting first, which
+  nothing can block) or (b) one's own choice to deposit into an already-diluted pool.
+- **Reentrancy / CEI**: all token-moving externals (`deposit`, `donate`, `withdraw`, `execute`,
+  `redeemInvite`) are `nonReentrant` and write state before transferring; weird tokens
+  (fee-on-transfer, rebasing) are excluded by the admin allowlist.
+
+## 4. Scope (v1) and extensions
+
+Implemented: the full deposit/donate/withdraw ledger, EIP-712 invites, snapshot voting, early
+execution, execution expiry, white-label naming, and the one-call frontend views
+(`getFund(s)`, `getProposals`, `proposalState`, `isExecutable`, `previewWithdraw`,
+`checkMemberships`). 100 unit tests in `test/unit/CollectiveFundCirclesUnit.t.sol`.
+
+Deferred (documented extension points): member removal via tombstones, ERC-4626-style
+parity-preserving mint, earmarked (spend-only) donations, vote-by-signature, per-fund
+`metadataURI`/ERC-7572, multi-recipient or cancellable proposals, and a decommission/sunset mode.
+The contract is standalone and does not touch `SavingCircles`.

--- a/docs/goal-saving-circles.md
+++ b/docs/goal-saving-circles.md
@@ -1,0 +1,105 @@
+# Goal Saving Circles
+
+*Goal-based group savings: a small group commits to saving toward a concrete target — "5,000 BREAD
+for the neighborhood oven" — by a date.*
+
+This document is the design rationale for `src/contracts/GoalSavingCircles.sol`. The full
+implementable spec (storage layout, exact math, complete test plan) lives in the design notes that
+produced it; this is the short version for reviewers.
+
+---
+
+## 0. What problem it solves
+
+Saving alone is hard; the commitment device of a group with a shared, visible target makes it
+easier. The organizer creates the goal and invites members with the same signed `StacksInvite`
+links the app already uses for `SavingCircles`. Members deposit whatever they can, whenever they
+can. Until the goal resolves, the money is locked — that lock IS the product. This is deliberately
+the simplest stack type: no credit, no interest, no auctions, no rounds, and **no division
+anywhere** — the contract only ever adds and subtracts exact deposit amounts.
+
+## 1. The mechanism
+
+A goal is an immutable config fixed at `create`: `(owner, token, beneficiary, goalAmount,
+deadline)`. The creator is the goal owner and its first member. State is **derived, never stored**:
+
+```
+cancelled  → Cancelled          (owner called cancel during Funding; terminal)
+released   → Released           (pot paid to beneficiary; terminal)
+goalReached→ Funded             (one-way latch: pot once hit goalAmount)
+now >= deadline → Failed        (unmet at the deadline; refunds open)
+otherwise  → Funding            (locked, accepting deposits)
+```
+
+- **Deposits** (`deposit` / `depositFor`): any member, any amount, any number of times, strictly
+  before the deadline. Overshoot is allowed — deposits stay open until the deadline even after the
+  goal is met, and `release` pays goal + overshoot. The first deposit that makes
+  `totalDeposited >= goalAmount` latches `goalReached` and emits `GoalReached` exactly once.
+- **Invites** (`redeemInvite`): EIP-712 `StacksInvite`/`1` domain, `Invite(uint256 id,uint256
+  nonce)` typehash — identical to `SavingCircles`, differing only by `verifyingContract`, so the
+  app's invite flow ports unchanged. Nonces are per-goal. Joins share the same "open" predicate as
+  deposits, so latecomers can still help overshoot.
+- **Success with a beneficiary**: `release` is permissionless once Funded, forever (no time
+  limit), and pays the whole pot to the pre-agreed beneficiary. Contributions are left untouched
+  as historical receipts.
+- **Success without a beneficiary** (commitment-savings mode): each member simply `withdraw`s
+  exactly what they put in. The `goalReached` latch never clears, even if withdrawals drop the
+  live pot below `goalAmount` — "the goal was achieved" is a historical fact, and re-locking
+  would punish early withdrawers.
+- **Failure or cancellation**: everyone `withdraw`s a full refund of exactly their own
+  contributions. `cancel` is goal-owner-only, Funding-only, and moves no tokens — it only unlocks
+  refunds earlier.
+
+The deadline boundary is exclusive: at `block.timestamp == deadline` an unmet goal is already
+Failed and deposits/joins revert.
+
+## 2. Safety invariants
+
+- **Solvency (per token, equality):** the contract's balance of `T` equals
+  `Σ totalDeposited[id]` over goals using `T` (plus any unsolicited donations). Every increment of
+  `totalDeposited` is matched by a `safeTransferFrom` pull in the same call; every decrement by a
+  `safeTransfer` out. There is no other balance-touching path.
+- **Per-goal ledger:** unless released, `totalDeposited[id] == Σ contributions[id][m]`. After
+  release, `totalDeposited[id] == 0` and contributions persist as receipts (unreachable by
+  `withdraw`, since Released is not refundable).
+- **No honest member ever loses principal.** The only outflows are (a) `withdraw`, paying a
+  member exactly their own recorded contributions, and (b) `release`, which requires the precise
+  success condition every member accepted when depositing into a goal whose immutable config named
+  that beneficiary. There is no debt, no default, no seizure: a member who stops depositing costs
+  the others nothing but goal-success probability. Members risk only time-lock (worst case: funds
+  locked until the deadline, then fully refundable).
+- **Latch monotonicity:** `goalReached`, `cancelled`, `released` transition false→true only;
+  Cancelled and Released are terminal; Failed is terminal because deposits close at the deadline.
+- **No custody for anyone:** the goal owner can only sign invites and cancel (which never
+  redirects funds); the registry admin only gates which tokens NEW goals may use (allowlist
+  changes never affect existing goals, which store their token).
+
+## 3. Decisions worth defending
+
+- **`msg.sender` is the goal owner** (no `owner` parameter at create): the owner's only powers
+  are invites and cancel; third-party appointment adds checks for zero product value.
+- **Overshoot allowed** rather than clamping the crossing deposit: clamping needs a
+  partial-refund branch or exact-remainder UX; overshoot is strictly simpler, strictly better for
+  the beneficiary, and harmless in no-beneficiary mode.
+- **`totalDeposited` is the live escrow** (decremented on withdraw, zeroed on release) with a
+  separate one-way `goalReached` latch, instead of a cumulative counter — the solvency invariant
+  becomes a single equality and the app's progress bar shows the actual pot.
+- **Full-balance withdrawals only**: partial refunds add parameters and no value.
+- **Re-entrancy**: all token-moving externals are `nonReentrant` and follow
+  checks-effects-interactions; `release` sets `released` and zeroes the pot before transferring.
+- **Weird tokens are out of scope**: the admin allowlist must exclude fee-on-transfer and
+  rebasing tokens (documented on `setTokenAllowed`), matching repo policy.
+
+## 4. Implementation scope (v1)
+
+Implemented: invite-only membership, flexible deposits with the `GoalReached` latch, both success
+modes (beneficiary release / commitment-savings withdrawal), failure refunds, owner cancellation,
+and the full view surface — behind an OZ v5 `TransparentUpgradeableProxy`, with ~80 unit tests in
+`test/unit/GoalSavingCirclesUnit.t.sol` covering every revert branch, state transition, and
+boundary.
+
+Deferred (documented extension points): open/permissionless-join goals; non-member donations that
+waive refund rights; partial withdrawals; per-member caps or scheduled installments; yield on the
+locked pot; member-quorum cancel or mutable config; a beneficiary claim expiry with
+fallback-to-refund; and Chainlink automation to auto-release on Funded. The contract is standalone
+and does not touch `SavingCircles`.

--- a/script/Common.sol
+++ b/script/Common.sol
@@ -5,7 +5,10 @@ import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transpa
 import {Script} from 'forge-std/Script.sol';
 import {console2} from 'forge-std/console2.sol';
 
+import {AccumulatingSavingCircles} from '../src/contracts/AccumulatingSavingCircles.sol';
 import {AutomaticSavingCircles} from '../src/contracts/AutomaticSavingCircles.sol';
+import {CollectiveFundCircles} from '../src/contracts/CollectiveFundCircles.sol';
+import {GoalSavingCircles} from '../src/contracts/GoalSavingCircles.sol';
 import {SavingCircles} from '../src/contracts/SavingCircles.sol';
 import {SavingCirclesViewer} from '../src/contracts/SavingCirclesViewer.sol';
 
@@ -39,9 +42,27 @@ contract Common is Script {
     AutomaticSavingCircles automaticSavingCircles = new AutomaticSavingCircles(address(proxy), _admin);
     SavingCirclesViewer savingCirclesViewer = new SavingCirclesViewer(address(proxy));
 
+    // Deploy the other stack types behind their own transparent proxies
+    TransparentUpgradeableProxy accumulatingProxy = _deployTransparentProxy(
+      address(new AccumulatingSavingCircles()),
+      _admin,
+      abi.encodeWithSelector(AccumulatingSavingCircles.initialize.selector, _admin)
+    );
+    TransparentUpgradeableProxy goalProxy = _deployTransparentProxy(
+      address(new GoalSavingCircles()), _admin, abi.encodeWithSelector(GoalSavingCircles.initialize.selector, _admin)
+    );
+    TransparentUpgradeableProxy collectiveProxy = _deployTransparentProxy(
+      address(new CollectiveFundCircles()),
+      _admin,
+      abi.encodeWithSelector(CollectiveFundCircles.initialize.selector, _admin)
+    );
+
     console2.log('SavingCircles proxy:', address(proxy));
     console2.log('AutomaticSavingCircles:', address(automaticSavingCircles));
     console2.log('SavingCirclesViewer:', address(savingCirclesViewer));
+    console2.log('AccumulatingSavingCircles proxy:', address(accumulatingProxy));
+    console2.log('GoalSavingCircles proxy:', address(goalProxy));
+    console2.log('CollectiveFundCircles proxy:', address(collectiveProxy));
 
     return proxy;
   }

--- a/script/Common.sol
+++ b/script/Common.sol
@@ -11,6 +11,7 @@ import {CollectiveFundCircles} from '../src/contracts/CollectiveFundCircles.sol'
 import {GoalSavingCircles} from '../src/contracts/GoalSavingCircles.sol';
 import {SavingCircles} from '../src/contracts/SavingCircles.sol';
 import {SavingCirclesViewer} from '../src/contracts/SavingCirclesViewer.sol';
+import {SEPOLIA_CHAIN_ID, SEPOLIA_TEST_TOKEN} from './Registry.sol';
 
 /**
  * @title Common Contract
@@ -19,6 +20,24 @@ import {SavingCirclesViewer} from '../src/contracts/SavingCirclesViewer.sol';
  * @dev This contract is intended for use in Scripts and Integration Tests
  */
 contract Common is Script {
+  /**
+   * @notice Every registry deployed by _deployAll
+   * @param savingCircles The rotating saving circles (ROSCA) proxy
+   * @param automaticSavingCircles The Chainlink automation satellite
+   * @param savingCirclesViewer The read aggregation satellite
+   * @param accumulatingSavingCircles The ASCA proxy
+   * @param goalSavingCircles The goal savings proxy
+   * @param collectiveFundCircles The collective fund proxy
+   */
+  struct Deployment {
+    TransparentUpgradeableProxy savingCircles;
+    AutomaticSavingCircles automaticSavingCircles;
+    SavingCirclesViewer savingCirclesViewer;
+    TransparentUpgradeableProxy accumulatingSavingCircles;
+    TransparentUpgradeableProxy goalSavingCircles;
+    TransparentUpgradeableProxy collectiveFundCircles;
+  }
+
   function setUp() public virtual {}
 
   function _deploySavingCircles() internal returns (SavingCircles) {
@@ -34,6 +53,10 @@ contract Common is Script {
   }
 
   function _deployContracts(address _admin) internal returns (TransparentUpgradeableProxy) {
+    return _deployAll(_admin).savingCircles;
+  }
+
+  function _deployAll(address _admin) internal returns (Deployment memory) {
     TransparentUpgradeableProxy proxy = _deployTransparentProxy(
       address(_deploySavingCircles()), _admin, abi.encodeWithSelector(SavingCircles.initialize.selector, _admin)
     );
@@ -64,6 +87,49 @@ contract Common is Script {
     console2.log('GoalSavingCircles proxy:', address(goalProxy));
     console2.log('CollectiveFundCircles proxy:', address(collectiveProxy));
 
-    return proxy;
+    return Deployment({
+      savingCircles: proxy,
+      automaticSavingCircles: automaticSavingCircles,
+      savingCirclesViewer: savingCirclesViewer,
+      accumulatingSavingCircles: accumulatingProxy,
+      goalSavingCircles: goalProxy,
+      collectiveFundCircles: collectiveProxy
+    });
+  }
+
+  /**
+   * @dev Allow a token on every registry so a fresh deployment is usable straight away.
+   *      Testnet deployments are throwaway and would otherwise need a manual owner
+   *      transaction before anyone can create a stack. On chains with no token configured
+   *      this is a no-op.
+   * @dev The calls are deliberately NOT wrapped in try/catch: forge only records calls for
+   *      broadcast outside a try context, so a try/catch here would simulate successfully
+   *      and then silently never be broadcast, leaving the deployment un-allowlisted. A
+   *      deployer that does not own the registries means ADMIN_ADDRESS does not match the
+   *      broadcasting key, which should fail the deployment loudly.
+   */
+  function _allowlistToken(Deployment memory _deployment, address _token) internal {
+    if (_token == address(0)) return;
+
+    address[4] memory registries = [
+      address(_deployment.savingCircles),
+      address(_deployment.accumulatingSavingCircles),
+      address(_deployment.goalSavingCircles),
+      address(_deployment.collectiveFundCircles)
+    ];
+
+    for (uint256 i = 0; i < registries.length; i++) {
+      SavingCircles(registries[i]).setTokenAllowed(_token, true);
+      console2.log('Allowed token on:', registries[i]);
+    }
+  }
+
+  /// @dev The token to allow at deploy time, or address(0) when the chain has none configured.
+  ///      ALLOWLIST_TOKEN overrides the per-chain default.
+  function _tokenToAllowlist() internal view returns (address) {
+    address configured = vm.envOr('ALLOWLIST_TOKEN', address(0));
+    if (configured != address(0)) return configured;
+    if (block.chainid == SEPOLIA_CHAIN_ID) return SEPOLIA_TEST_TOKEN;
+    return address(0);
   }
 }

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -8,7 +8,8 @@ contract Deploy is Common {
     address admin = vm.envAddress('ADMIN_ADDRESS');
     vm.startBroadcast();
 
-    _deployContracts(admin);
+    Deployment memory deployment = _deployAll(admin);
+    _allowlistToken(deployment, _tokenToAllowlist());
 
     vm.stopBroadcast();
   }

--- a/script/Registry.sol
+++ b/script/Registry.sol
@@ -10,6 +10,12 @@ address constant OPTIMISM_DAI = 0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1;
 address constant GNOSIS_BREAD = 0xa555d5344f6FB6c65da19e403Cb4c1eC4a1a5Ee3;
 address constant GNOSIS_XDAI = 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d;
 
+// Tokens (Sepolia testnet) - the mock token the Stacks testnet front end funds users with
+address constant SEPOLIA_TEST_TOKEN = 0x30142762922fa1594eA0b9e2e9a3b167F5FF31B0;
+
+// Chain ids
+uint256 constant SEPOLIA_CHAIN_ID = 11_155_111;
+
 // Curve Factory (Gnosis Chain)
 address constant GNOSIS_CURVE_STABLE_SWAP_FACTORY = 0xbC0797015fcFc47d9C1856639CaE50D0e69FbEE8;
 

--- a/src/contracts/AccumulatingSavingCircles.sol
+++ b/src/contracts/AccumulatingSavingCircles.sol
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {ReentrancyGuardUpgradeable} from '@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol';
+import {EIP712Upgradeable} from '@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ECDSA} from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+
+import {IAccumulatingSavingCircles} from 'interfaces/IAccumulatingSavingCircles.sol';
+
+using SafeERC20 for IERC20;
+
+/**
+ * @title Accumulating Saving Circles
+ * @notice An Accumulating Savings and Credit Association (ASCA) registry: members deposit flexible
+ *         amounts into a shared pool, earn a credit line proportional to their own savings, borrow
+ *         against it, and repay within a fixed number of periods with optional simple interest that
+ *         streams pro-rata to savers via a MasterChef-style per-share accumulator.
+ * @dev Safety rests on full self-collateralization: `borrowLimitBps <= 10_000` implies
+ *      `principal <= savings` for every open loan, preserved by the withdraw collateral guard
+ *      (which counts accrued interest as debt) and cleared by permissionless {liquidate} at the
+ *      due date, so a defaulter can only ever burn their own savings, never another member's
+ *      principal. All accounting uses the internal `poolCash` ledger, never `token.balanceOf`,
+ *      so donations and multi-fund interactions cannot corrupt state. Interest accrues lazily per
+ *      whole elapsed period, capped at `repaymentPeriods` periods, so a borrower's liability is
+ *      bounded at borrow time and the liquidation seizure is deterministic.
+ * @author Breadchain Collective
+ * @author @RonTuretzky
+ */
+contract AccumulatingSavingCircles is
+  IAccumulatingSavingCircles,
+  ReentrancyGuardUpgradeable,
+  OwnableUpgradeable,
+  EIP712Upgradeable
+{
+  /// @notice Basis-point denominator.
+  uint256 public constant MAX_BPS = 10_000;
+  /// @notice Sanity cap on a fund's repayment periods; bounds interest and due-date math.
+  uint256 public constant MAX_REPAYMENT_PERIODS = 1000;
+  /// @notice Sanity cap on a fund's period length; bounds due-date math.
+  uint256 public constant MAX_PERIOD_LENGTH = 365 days;
+  /// @dev Accumulator scaling factor.
+  uint256 internal constant _ACC_PRECISION = 1e18;
+  string private constant _EIP712_NAME = 'StacksInvite';
+  string private constant _EIP712_VERSION = '1';
+  bytes32 private constant _INVITE_TYPEHASH = keccak256('Invite(uint256 id,uint256 nonce)');
+
+  /// @notice Next fund id to be assigned (funds are keyed 0..nextId-1).
+  uint256 public nextId;
+
+  /// @notice Admin token allowlist (checked at create only).
+  mapping(address token => bool allowed) public allowedTokens;
+
+  /// @dev Fund configuration + lifecycle flag. fund.owner == address(0) <=> fund does not exist.
+  mapping(uint256 id => Fund fund) internal _funds;
+
+  /// @dev Ordered member roster (append-only; members are never removed).
+  mapping(uint256 id => address[] members) internal _members;
+
+  /// @notice Membership flag.
+  mapping(uint256 id => mapping(address member => bool status)) public isMember;
+
+  /// @dev Reverse index: every fund an address has ever joined (append-only).
+  mapping(address member => uint256[] ids) internal _memberFunds;
+
+  /// @notice Spent EIP-712 invite nonces, per fund.
+  mapping(uint256 id => mapping(uint256 nonce => bool used)) public usedNonces;
+
+  /// @notice Member's savings principal in the fund (the collateral base and the accumulator shares).
+  mapping(uint256 id => mapping(address member => uint256 amount)) public savings;
+
+  /// @dev MasterChef reward debt: savings[id][m] * accInterestPerShare[id] / 1e18 at last checkpoint.
+  mapping(uint256 id => mapping(address member => uint256 amount)) internal _rewardDebt;
+
+  /// @notice Interest already settled to the member (claimable via claimInterest), not yet transferred.
+  mapping(uint256 id => mapping(address member => uint256 amount)) public interestCredit;
+
+  /// @dev Member's open loan. principal == 0 <=> no loan (all other fields are then stale/zero).
+  mapping(uint256 id => mapping(address member => Loan loan)) internal _loans;
+
+  /// @notice Sum of all members' savings (the accumulator share supply).
+  mapping(uint256 id => uint256 amount) public totalSavings;
+
+  /// @notice Sum of all outstanding loan principal.
+  mapping(uint256 id => uint256 amount) public totalBorrowed;
+
+  /// @notice Fund's internal cash ledger: tokens received minus tokens sent for this fund.
+  ///         Never read token.balanceOf for logic (donation-proof, multi-fund-safe).
+  mapping(uint256 id => uint256 amount) public poolCash;
+
+  /// @notice Cumulative distributed interest per savings share, scaled by 1e18. Monotone non-decreasing.
+  mapping(uint256 id => uint256 acc) public accInterestPerShare;
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function initialize(address _owner) external override initializer {
+    __EIP712_init(_EIP712_NAME, _EIP712_VERSION);
+    __Ownable_init(_owner);
+    __ReentrancyGuard_init();
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function setTokenAllowed(address _token, bool _allowed) external override onlyOwner {
+    allowedTokens[_token] = _allowed;
+
+    emit TokenAllowed(_token, _allowed);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function create(
+    address _token,
+    uint256 _borrowLimitBps,
+    uint256 _interestRateBps,
+    uint256 _repaymentPeriods,
+    uint256 _periodLength
+  ) external override returns (uint256 _id) {
+    if (!allowedTokens[_token]) revert TokenNotAllowed();
+    if (_borrowLimitBps > MAX_BPS || _interestRateBps > MAX_BPS) revert InvalidParameters();
+    if (_repaymentPeriods == 0 || _repaymentPeriods > MAX_REPAYMENT_PERIODS) revert InvalidParameters();
+    if (_periodLength == 0 || _periodLength > MAX_PERIOD_LENGTH) revert InvalidParameters();
+
+    _id = nextId++;
+
+    _funds[_id] = Fund({
+      owner: msg.sender,
+      token: _token,
+      borrowLimitBps: _borrowLimitBps,
+      interestRateBps: _interestRateBps,
+      repaymentPeriods: _repaymentPeriods,
+      periodLength: _periodLength,
+      deactivated: false
+    });
+
+    isMember[_id][msg.sender] = true;
+    _members[_id].push(msg.sender);
+    _memberFunds[msg.sender].push(_id);
+
+    emit FundCreated(_id, msg.sender, _token, _borrowLimitBps, _interestRateBps, _repaymentPeriods, _periodLength);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function redeemInvite(uint256 _id, uint256 _nonce, bytes calldata _signature) external override nonReentrant {
+    Fund storage _fund = _existingFund(_id);
+    if (_fund.deactivated) revert FundNotActive();
+    if (usedNonces[_id][_nonce]) revert InviteAlreadyUsed();
+    if (isMember[_id][msg.sender]) revert AlreadyMember();
+
+    address _signer = ECDSA.recover(_hashInvite(_id, _nonce), _signature);
+    if (_signer != _fund.owner) revert InvalidSigner();
+
+    usedNonces[_id][_nonce] = true;
+    isMember[_id][msg.sender] = true;
+    _members[_id].push(msg.sender);
+    _memberFunds[msg.sender].push(_id);
+
+    emit InviteRedeemed(_id, msg.sender);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function deactivate(uint256 _id) external override {
+    Fund storage _fund = _existingFund(_id);
+    if (msg.sender != _fund.owner) revert NotFundOwner();
+    if (_fund.deactivated) revert FundNotActive();
+
+    _fund.deactivated = true;
+
+    emit FundDeactivated(_id);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function deposit(uint256 _id, uint256 _amount) external override nonReentrant {
+    _deposit(_id, msg.sender, _amount);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function depositFor(uint256 _id, address _member, uint256 _amount) external override nonReentrant {
+    _deposit(_id, _member, _amount);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function withdraw(uint256 _id, uint256 _amount) external override nonReentrant {
+    Fund storage _fund = _existingFund(_id);
+    if (_amount == 0) revert ZeroAmount();
+    if (!isMember[_id][msg.sender]) revert NotMember();
+
+    uint256 _memberSavings = savings[_id][msg.sender];
+    if (_amount > _memberSavings) revert InsufficientSavings();
+
+    Loan storage _loan = _loans[_id][msg.sender];
+    if (_loan.principal != 0) {
+      _accrue(_id, msg.sender);
+      uint256 _debt = _loan.principal + _loan.interestOwed;
+      if (_debt * MAX_BPS > _fund.borrowLimitBps * (_memberSavings - _amount)) revert InsufficientCollateral();
+    }
+    if (poolCash[_id] < _amount) revert InsufficientLiquidity();
+
+    _settle(_id, msg.sender);
+    savings[_id][msg.sender] = _memberSavings - _amount;
+    totalSavings[_id] -= _amount;
+    poolCash[_id] -= _amount;
+    _checkpoint(_id, msg.sender);
+
+    IERC20(_fund.token).safeTransfer(msg.sender, _amount);
+
+    emit SavingsWithdrawn(_id, msg.sender, _amount);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function claimInterest(uint256 _id) external override nonReentrant {
+    Fund storage _fund = _existingFund(_id);
+
+    uint256 _amount = _pendingInterestOf(_id, msg.sender);
+    if (_amount == 0) revert NothingToClaim();
+    if (poolCash[_id] < _amount) revert InsufficientLiquidity();
+
+    interestCredit[_id][msg.sender] = 0;
+    _checkpoint(_id, msg.sender);
+    poolCash[_id] -= _amount;
+
+    IERC20(_fund.token).safeTransfer(msg.sender, _amount);
+
+    emit InterestClaimed(_id, msg.sender, _amount);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function borrow(uint256 _id, uint256 _amount) external override nonReentrant {
+    Fund storage _fund = _existingFund(_id);
+    if (_fund.deactivated) revert FundNotActive();
+    if (_amount == 0) revert ZeroAmount();
+    if (!isMember[_id][msg.sender]) revert NotMember();
+
+    Loan storage _loan = _loans[_id][msg.sender];
+    if (_loan.principal != 0) revert OutstandingLoan();
+    if (_amount * MAX_BPS > _fund.borrowLimitBps * savings[_id][msg.sender]) revert ExceedsCreditLine();
+    if (poolCash[_id] < _amount) revert InsufficientLiquidity();
+
+    _loan.principal = _amount;
+    _loan.interestOwed = 0;
+    _loan.periodsAccrued = 0;
+    _loan.startTime = block.timestamp;
+
+    totalBorrowed[_id] += _amount;
+    poolCash[_id] -= _amount;
+
+    uint256 _dueDate = block.timestamp + _fund.repaymentPeriods * _fund.periodLength;
+
+    IERC20(_fund.token).safeTransfer(msg.sender, _amount);
+
+    emit Borrowed(_id, msg.sender, _amount, _dueDate);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function repay(uint256 _id, uint256 _amount) external override nonReentrant {
+    Fund storage _fund = _existingFund(_id);
+    if (_amount == 0) revert ZeroAmount();
+
+    Loan storage _loan = _loans[_id][msg.sender];
+    if (_loan.principal == 0) revert NoActiveLoan();
+
+    _accrue(_id, msg.sender);
+
+    uint256 _totalDebt = _loan.interestOwed + _loan.principal;
+    uint256 _pay = _amount < _totalDebt ? _amount : _totalDebt;
+    uint256 _interestPart = _pay < _loan.interestOwed ? _pay : _loan.interestOwed;
+    uint256 _principalPart = _pay - _interestPart;
+
+    _loan.interestOwed -= _interestPart;
+    _loan.principal -= _principalPart;
+    totalBorrowed[_id] -= _principalPart;
+    poolCash[_id] += _pay;
+
+    // Interest is retired before principal, so a fully repaid loan owes nothing and can be deleted.
+    if (_loan.principal == 0) delete _loans[_id][msg.sender];
+
+    _distributeInterest(_id, _interestPart);
+
+    IERC20(_fund.token).safeTransferFrom(msg.sender, address(this), _pay);
+
+    emit Repaid(_id, msg.sender, _interestPart, _principalPart);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function liquidate(uint256 _id, address _member) external override nonReentrant {
+    Fund storage _fund = _existingFund(_id);
+
+    Loan storage _loan = _loans[_id][_member];
+    if (_loan.principal == 0) revert NoActiveLoan();
+    if (block.timestamp < _loan.startTime + _fund.repaymentPeriods * _fund.periodLength) revert NotLiquidatable();
+
+    _accrue(_id, _member); // capped at repaymentPeriods => frozen at the due date
+    _settle(_id, _member); // bank the member's own pending interest first
+
+    uint256 _seizedPrincipal = _loan.principal; // savings >= principal guaranteed (invariant I2)
+    uint256 _remaining = savings[_id][_member] - _seizedPrincipal;
+    uint256 _seizedInterest = _loan.interestOwed < _remaining ? _loan.interestOwed : _remaining;
+    // If seizing interest would leave no savings shares in the fund, there is nobody to
+    // distribute it to; leave it as the defaulter's savings instead of burning it.
+    if (totalSavings[_id] - _seizedPrincipal - _seizedInterest == 0) _seizedInterest = 0;
+
+    savings[_id][_member] -= _seizedPrincipal + _seizedInterest;
+    totalSavings[_id] -= _seizedPrincipal + _seizedInterest;
+    totalBorrowed[_id] -= _seizedPrincipal;
+    _checkpoint(_id, _member);
+    delete _loans[_id][_member];
+
+    _distributeInterest(_id, _seizedInterest);
+
+    emit Liquidated(_id, _member, _seizedPrincipal, _seizedInterest);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function isTokenAllowed(address _token) external view override returns (bool _allowed) {
+    return allowedTokens[_token];
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function getFund(uint256 _id) external view override returns (Fund memory _fund) {
+    return _existingFund(_id);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function getFundMembers(uint256 _id) external view override returns (address[] memory _fundMembers) {
+    return _members[_id];
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function getMemberFunds(address _member) external view override returns (uint256[] memory _ids) {
+    return _memberFunds[_member];
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function getFundBalances(uint256 _id)
+    external
+    view
+    override
+    returns (uint256 totalSavings_, uint256 totalBorrowed_, uint256 poolCash_)
+  {
+    return (totalSavings[_id], totalBorrowed[_id], poolCash[_id]);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function getLoan(uint256 _id, address _member) external view override returns (Loan memory _loan, uint256 _dueDate) {
+    _loan = _loans[_id][_member];
+    if (_loan.principal == 0) return (_loan, 0);
+
+    Fund storage _fund = _funds[_id];
+    uint256 _elapsed = (block.timestamp - _loan.startTime) / _fund.periodLength;
+    uint256 _periods = _elapsed < _fund.repaymentPeriods ? _elapsed : _fund.repaymentPeriods;
+    _loan.interestOwed += _loan.principal * _fund.interestRateBps * (_periods - _loan.periodsAccrued) / MAX_BPS;
+    _loan.periodsAccrued = _periods;
+    _dueDate = _loan.startTime + _fund.repaymentPeriods * _fund.periodLength;
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function creditLineOf(uint256 _id, address _member) external view override returns (uint256 _amount) {
+    return _funds[_id].borrowLimitBps * savings[_id][_member] / MAX_BPS;
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function maxBorrowableOf(uint256 _id, address _member) external view override returns (uint256 _amount) {
+    Fund storage _fund = _funds[_id];
+    if (_fund.deactivated || _loans[_id][_member].principal != 0) return 0;
+
+    uint256 _creditLine = _fund.borrowLimitBps * savings[_id][_member] / MAX_BPS;
+    uint256 _cash = poolCash[_id];
+    return _creditLine < _cash ? _creditLine : _cash;
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function pendingInterestOf(uint256 _id, address _member) external view override returns (uint256 _amount) {
+    return _pendingInterestOf(_id, _member);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function withdrawableOf(uint256 _id, address _member) external view override returns (uint256 _amount) {
+    return savings[_id][_member] + _pendingInterestOf(_id, _member);
+  }
+
+  /// @inheritdoc IAccumulatingSavingCircles
+  function isLiquidatable(uint256 _id, address _member) external view override returns (bool _liquidatable) {
+    Loan storage _loan = _loans[_id][_member];
+    if (_loan.principal == 0) return false;
+
+    Fund storage _fund = _funds[_id];
+    return block.timestamp >= _loan.startTime + _fund.repaymentPeriods * _fund.periodLength;
+  }
+
+  /**
+   * @dev Deposit `_amount` of savings for `_member`, funded by msg.sender. Settles the member's
+   *      pending interest before the share balance changes so past distributions are not diluted.
+   * @param _id The fund id.
+   * @param _member The member to credit.
+   * @param _amount The amount to deposit.
+   */
+  function _deposit(uint256 _id, address _member, uint256 _amount) internal {
+    Fund storage _fund = _existingFund(_id);
+    if (_fund.deactivated) revert FundNotActive();
+    if (_amount == 0) revert ZeroAmount();
+    if (!isMember[_id][_member]) revert NotMember();
+
+    _settle(_id, _member);
+    savings[_id][_member] += _amount;
+    totalSavings[_id] += _amount;
+    poolCash[_id] += _amount;
+    _checkpoint(_id, _member);
+
+    IERC20(_fund.token).safeTransferFrom(msg.sender, address(this), _amount);
+
+    emit SavingsDeposited(_id, _member, _amount);
+  }
+
+  /**
+   * @dev Lazily checkpoint a loan's simple interest: accrue `principal * rateBps / MAX_BPS` per
+   *      whole elapsed period (floor), capped at `repaymentPeriods` periods so accrual stops at
+   *      the due date. Zero whole periods elapsed means zero interest.
+   * @param _id The fund id.
+   * @param _member The borrower.
+   */
+  function _accrue(uint256 _id, address _member) internal {
+    Loan storage _loan = _loans[_id][_member];
+    Fund storage _fund = _funds[_id];
+
+    uint256 _elapsed = (block.timestamp - _loan.startTime) / _fund.periodLength;
+    uint256 _periods = _elapsed < _fund.repaymentPeriods ? _elapsed : _fund.repaymentPeriods;
+    if (_periods > _loan.periodsAccrued) {
+      _loan.interestOwed += _loan.principal * _fund.interestRateBps * (_periods - _loan.periodsAccrued) / MAX_BPS;
+      _loan.periodsAccrued = _periods;
+    }
+  }
+
+  /**
+   * @dev Bank a member's unsettled accumulator share into `interestCredit`. MUST be called before
+   *      any change to `savings[_id][_member]`; the caller MUST call {_checkpoint} afterwards.
+   * @param _id The fund id.
+   * @param _member The member.
+   */
+  function _settle(uint256 _id, address _member) internal {
+    uint256 _pending = savings[_id][_member] * accInterestPerShare[_id] / _ACC_PRECISION - _rewardDebt[_id][_member];
+    if (_pending != 0) interestCredit[_id][_member] += _pending;
+  }
+
+  /**
+   * @dev Re-anchor a member's reward debt to their current savings and the current accumulator.
+   * @param _id The fund id.
+   * @param _member The member.
+   */
+  function _checkpoint(uint256 _id, address _member) internal {
+    _rewardDebt[_id][_member] = savings[_id][_member] * accInterestPerShare[_id] / _ACC_PRECISION;
+  }
+
+  /**
+   * @dev Distribute `_amount` of realized interest pro-rata to savers by bumping the accumulator.
+   *      Floor rounding leaves sub-wei-per-share dust in `poolCash` as an untracked surplus, so
+   *      assets >= liabilities is preserved. Callers guarantee `totalSavings[_id] > 0` when
+   *      `_amount > 0`.
+   * @param _id The fund id.
+   * @param _amount The interest amount to distribute.
+   */
+  function _distributeInterest(uint256 _id, uint256 _amount) internal {
+    if (_amount == 0) return;
+    accInterestPerShare[_id] += _amount * _ACC_PRECISION / totalSavings[_id];
+
+    emit InterestDistributed(_id, _amount);
+  }
+
+  /**
+   * @dev A member's unclaimed interest: settled credit plus the unsettled accumulator share.
+   * @param _id The fund id.
+   * @param _member The member.
+   * @return _amount The unclaimed interest.
+   */
+  function _pendingInterestOf(uint256 _id, address _member) internal view returns (uint256 _amount) {
+    return interestCredit[_id][_member] + savings[_id][_member] * accInterestPerShare[_id] / _ACC_PRECISION
+      - _rewardDebt[_id][_member];
+  }
+
+  /**
+   * @dev Fetch a fund, reverting with FundNotFound if it does not exist.
+   * @param _id The fund id.
+   * @return _fund The fund storage pointer.
+   */
+  function _existingFund(uint256 _id) internal view returns (Fund storage _fund) {
+    _fund = _funds[_id];
+    if (_fund.owner == address(0)) revert FundNotFound();
+  }
+
+  /**
+   * @dev Computes the EIP-712 hash for an invite
+   * @notice _INVITE_TYPEHASH is keccak256('Invite(uint256 id,uint256 nonce)')
+   */
+  function _hashInvite(uint256 _id, uint256 _nonce) private view returns (bytes32) {
+    bytes32 _structHash = keccak256(abi.encode(_INVITE_TYPEHASH, _id, _nonce));
+    return _hashTypedDataV4(_structHash);
+  }
+}

--- a/src/contracts/CollectiveFundCircles.sol
+++ b/src/contracts/CollectiveFundCircles.sol
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {ReentrancyGuardUpgradeable} from '@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol';
+import {EIP712Upgradeable} from '@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ECDSA} from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+
+import {ICollectiveFundCircles} from 'interfaces/ICollectiveFundCircles.sol';
+
+using SafeERC20 for IERC20;
+
+/**
+ * @title Collective Fund Circles
+ * @notice A communal savings pot for local communities: members deposit flexible amounts anytime,
+ *         may rage-quit anytime for a pro-rata slice of what remains, and spend the pool together
+ *         via one-member-one-vote disbursement proposals with a snapshotted electorate.
+ * @dev Singleton registry keyed by uint256 id; each fund carries its own on-chain display name
+ *      (white-label). Membership is by fund-owner-signed EIP-712 invite (domain 'StacksInvite',
+ *      identical to SavingCircles). Shares are a ledger of tokens contributed (minted 1:1, not
+ *      vault shares); an executed proposal dilutes every shareholder pro-rata. Rage-quit is never
+ *      blocked: a passed proposal does not reserve funds, and execute simply reverts if the pool
+ *      no longer covers the amount. See docs/collective-fund-circles.md for the design rationale.
+ * @author Breadchain Collective
+ */
+contract CollectiveFundCircles is
+  ICollectiveFundCircles,
+  ReentrancyGuardUpgradeable,
+  OwnableUpgradeable,
+  EIP712Upgradeable
+{
+  /// @notice Basis-point denominator
+  uint256 public constant MAX_BPS = 10_000;
+  /// @notice Upper bound on a fund's voting period; bounds deadline math so no overflow is possible
+  uint256 public constant MAX_VOTING_PERIOD = 365 days;
+
+  string private constant _EIP712_NAME = 'StacksInvite';
+  string private constant _EIP712_VERSION = '1';
+  bytes32 private constant _INVITE_TYPEHASH = keccak256('Invite(uint256 id,uint256 nonce)');
+
+  /// @inheritdoc ICollectiveFundCircles
+  uint256 public override nextId;
+
+  /// @notice Admin (contract owner) ERC20 allowlist, exactly like SavingCircles
+  mapping(address token => bool status) public allowedTokens;
+
+  /// @notice Fund config + accounting; `owner != address(0)` is the existence sentinel
+  mapping(uint256 id => Fund fund) internal _funds;
+
+  /// @inheritdoc ICollectiveFundCircles
+  mapping(uint256 id => mapping(address member => bool status)) public override isMember;
+
+  /// @notice APPEND-ONLY ordered member list. Never shuffled/shrunk — proposal electorate
+  ///         snapshots rely on `memberIndex < proposal.electorate`
+  mapping(uint256 id => address[] members) public fundMembers;
+
+  /// @inheritdoc ICollectiveFundCircles
+  mapping(uint256 id => mapping(address member => uint256 index)) public override memberIndex;
+
+  /// @inheritdoc ICollectiveFundCircles
+  mapping(uint256 id => mapping(address member => uint256 shares)) public override sharesOf;
+
+  /// @notice Reverse index: all fund ids an address is a member of (frontend enumeration)
+  mapping(address member => uint256[] ids) public memberFunds;
+
+  /// @inheritdoc ICollectiveFundCircles
+  mapping(uint256 id => mapping(uint256 nonce => bool used)) public override usedNonces;
+
+  /// @notice Proposals per fund, keyed by per-fund proposalId (0.._funds[id].proposalCount-1)
+  mapping(uint256 id => mapping(uint256 proposalId => Proposal proposal)) internal _proposals;
+
+  /// @inheritdoc ICollectiveFundCircles
+  mapping(uint256 id => mapping(uint256 proposalId => mapping(address voter => bool voted))) public override hasVoted;
+
+  /// @dev Requires the fund exists
+  modifier onlyExisting(uint256 _id) {
+    if (_funds[_id].owner == address(0)) revert FundNotFound();
+    _;
+  }
+
+  /// @dev Requires the address is a member of the fund
+  modifier onlyMember(uint256 _id, address _member) {
+    if (!isMember[_id][_member]) revert NotMember();
+    _;
+  }
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function initialize(address _owner) external override initializer {
+    __EIP712_init(_EIP712_NAME, _EIP712_VERSION);
+    __Ownable_init(_owner);
+    __ReentrancyGuard_init();
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function setTokenAllowed(address _token, bool _allowed) external override onlyOwner {
+    allowedTokens[_token] = _allowed;
+
+    emit TokenAllowed(_token, _allowed);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function create(
+    address _token,
+    address _fundOwner,
+    string calldata _name,
+    uint256 _votingPeriod,
+    uint256 _approvalThresholdBps
+  ) external override returns (uint256 _id) {
+    if (!allowedTokens[_token]) revert TokenNotAllowed();
+    if (_fundOwner == address(0)) revert InvalidFundOwner();
+    if (bytes(_name).length == 0) revert InvalidName();
+    if (_votingPeriod == 0 || _votingPeriod > MAX_VOTING_PERIOD) revert InvalidVotingPeriod();
+    if (_approvalThresholdBps == 0 || _approvalThresholdBps > MAX_BPS) revert InvalidThreshold();
+
+    _id = nextId++;
+
+    Fund storage _fund = _funds[_id];
+    _fund.owner = _fundOwner;
+    _fund.token = _token;
+    _fund.votingPeriod = _votingPeriod;
+    _fund.approvalThresholdBps = _approvalThresholdBps;
+    _fund.name = _name;
+
+    isMember[_id][_fundOwner] = true;
+    fundMembers[_id].push(_fundOwner);
+    memberIndex[_id][_fundOwner] = 0;
+    memberFunds[_fundOwner].push(_id);
+
+    emit FundCreated(_id, _fundOwner, _token, _name, _votingPeriod, _approvalThresholdBps);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function redeemInvite(
+    uint256 _id,
+    uint256 _nonce,
+    bytes calldata _signature
+  ) external override nonReentrant onlyExisting(_id) {
+    if (usedNonces[_id][_nonce]) revert InviteAlreadyUsed();
+    if (isMember[_id][msg.sender]) revert AlreadyMember();
+
+    bytes32 _digest = _hashInvite(_id, _nonce);
+    address _signer = ECDSA.recover(_digest, _signature);
+
+    if (_signer != _funds[_id].owner) revert InvalidSigner();
+
+    usedNonces[_id][_nonce] = true;
+
+    isMember[_id][msg.sender] = true;
+    address[] storage _members = fundMembers[_id];
+    _members.push(msg.sender);
+    memberIndex[_id][msg.sender] = _members.length - 1;
+    memberFunds[msg.sender].push(_id);
+
+    emit InviteRedeemed(_id, msg.sender);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function deposit(
+    uint256 _id,
+    uint256 _amount
+  ) external override nonReentrant onlyExisting(_id) onlyMember(_id, msg.sender) {
+    if (_amount == 0) revert InvalidAmount();
+
+    Fund storage _fund = _funds[_id];
+    sharesOf[_id][msg.sender] += _amount;
+    _fund.totalShares += _amount;
+    _fund.poolBalance += _amount;
+
+    IERC20(_fund.token).safeTransferFrom(msg.sender, address(this), _amount);
+
+    emit FundsDeposited(_id, msg.sender, _amount);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function donate(uint256 _id, uint256 _amount) external override nonReentrant onlyExisting(_id) {
+    if (_amount == 0) revert InvalidAmount();
+
+    Fund storage _fund = _funds[_id];
+    _fund.poolBalance += _amount;
+
+    IERC20(_fund.token).safeTransferFrom(msg.sender, address(this), _amount);
+
+    emit FundsDonated(_id, msg.sender, _amount);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function withdraw(
+    uint256 _id,
+    uint256 _shares
+  ) external override nonReentrant onlyExisting(_id) onlyMember(_id, msg.sender) {
+    if (_shares == 0) revert InvalidAmount();
+
+    uint256 _memberShares = sharesOf[_id][msg.sender];
+    if (_shares > _memberShares) revert InsufficientShares();
+
+    Fund storage _fund = _funds[_id];
+    // Pro-rata at time of withdrawal; floor division rounds in favor of the pool. Since
+    // _shares <= totalShares, _amountOut <= poolBalance and the debit below cannot underflow.
+    uint256 _amountOut = (_shares * _fund.poolBalance) / _fund.totalShares;
+
+    sharesOf[_id][msg.sender] = _memberShares - _shares;
+    _fund.totalShares -= _shares;
+    _fund.poolBalance -= _amountOut;
+
+    IERC20(_fund.token).safeTransfer(msg.sender, _amountOut);
+
+    emit FundsWithdrawn(_id, msg.sender, _shares, _amountOut);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function propose(
+    uint256 _id,
+    address _recipient,
+    uint256 _amount,
+    string calldata _description
+  ) external override onlyExisting(_id) onlyMember(_id, msg.sender) returns (uint256 _proposalId) {
+    if (_recipient == address(0) || _recipient == address(this)) revert InvalidRecipient();
+    if (_amount == 0) revert InvalidAmount();
+
+    Fund storage _fund = _funds[_id];
+    _proposalId = _fund.proposalCount++;
+
+    uint256 _electorate = fundMembers[_id].length;
+    // Ceiling division: "at least thresholdBps of the electorate" must not be satisfiable by
+    // fewer heads via flooring. Always >= 1 since electorate >= 1 and thresholdBps >= 1.
+    uint256 _requiredYes = (_electorate * _fund.approvalThresholdBps + MAX_BPS - 1) / MAX_BPS;
+
+    Proposal storage _proposal = _proposals[_id][_proposalId];
+    _proposal.proposer = msg.sender;
+    _proposal.recipient = _recipient;
+    _proposal.amount = _amount;
+    _proposal.createdAt = block.timestamp;
+    _proposal.electorate = _electorate;
+    _proposal.requiredYes = _requiredYes;
+    _proposal.yesVotes = 1; // proposer auto-votes yes
+    _proposal.description = _description;
+
+    hasVoted[_id][_proposalId][msg.sender] = true;
+
+    emit ProposalCreated(_id, _proposalId, msg.sender, _recipient, _amount, _description);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function vote(
+    uint256 _id,
+    uint256 _proposalId,
+    bool _support
+  ) external override onlyExisting(_id) onlyMember(_id, msg.sender) {
+    Fund storage _fund = _funds[_id];
+    if (_proposalId >= _fund.proposalCount) revert ProposalNotFound();
+
+    Proposal storage _proposal = _proposals[_id][_proposalId];
+    // Append-only member list makes "index < snapshot length" exactly "was a member at snapshot".
+    if (memberIndex[_id][msg.sender] >= _proposal.electorate) revert NotEligible();
+    if (_proposal.executed || block.timestamp > _proposal.createdAt + _fund.votingPeriod) revert VotingClosed();
+    if (hasVoted[_id][_proposalId][msg.sender]) revert AlreadyVoted();
+
+    hasVoted[_id][_proposalId][msg.sender] = true;
+    if (_support) {
+      _proposal.yesVotes += 1;
+    } else {
+      _proposal.noVotes += 1;
+    }
+
+    emit VoteCast(_id, _proposalId, msg.sender, _support);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function execute(uint256 _id, uint256 _proposalId) external override nonReentrant onlyExisting(_id) {
+    Fund storage _fund = _funds[_id];
+    if (_proposalId >= _fund.proposalCount) revert ProposalNotFound();
+
+    Proposal storage _proposal = _proposals[_id][_proposalId];
+    if (_proposal.yesVotes < _proposal.requiredYes) revert ProposalNotPassed();
+    if (_proposal.executed) revert ProposalAlreadyExecuted();
+    if (block.timestamp > _proposal.createdAt + 2 * _fund.votingPeriod) revert ProposalExpired();
+    if (_fund.poolBalance < _proposal.amount) revert InsufficientPoolBalance();
+
+    _proposal.executed = true;
+    _fund.poolBalance -= _proposal.amount;
+
+    IERC20(_fund.token).safeTransfer(_proposal.recipient, _proposal.amount);
+
+    emit ProposalExecuted(_id, _proposalId, _proposal.recipient, _proposal.amount);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function setFundName(uint256 _id, string calldata _name) external override onlyExisting(_id) {
+    if (msg.sender != _funds[_id].owner) revert NotFundOwner();
+    if (bytes(_name).length == 0) revert InvalidName();
+
+    _funds[_id].name = _name;
+
+    emit FundNameUpdated(_id, _name);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function getFund(uint256 _id) external view override onlyExisting(_id) returns (Fund memory _fund) {
+    return _funds[_id];
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function getFunds(uint256[] calldata _ids) external view override returns (Fund[] memory _result) {
+    _result = new Fund[](_ids.length);
+
+    for (uint256 _i = 0; _i < _ids.length; _i++) {
+      _result[_i] = _funds[_ids[_i]];
+    }
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function getFundMembers(uint256 _id) external view override returns (address[] memory _members) {
+    return fundMembers[_id];
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function getMemberFunds(address _member) external view override returns (uint256[] memory _ids) {
+    return memberFunds[_member];
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function checkMemberships(
+    address _member,
+    uint256[] calldata _ids
+  ) external view override returns (bool[] memory _memberships) {
+    _memberships = new bool[](_ids.length);
+
+    for (uint256 _i = 0; _i < _ids.length; _i++) {
+      _memberships[_i] = isMember[_ids[_i]][_member];
+    }
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function getProposal(uint256 _id, uint256 _proposalId) external view override returns (Proposal memory _proposal) {
+    if (_proposalId >= _funds[_id].proposalCount) revert ProposalNotFound();
+    return _proposals[_id][_proposalId];
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function getProposals(uint256 _id) external view override returns (Proposal[] memory _result) {
+    uint256 _count = _funds[_id].proposalCount;
+    _result = new Proposal[](_count);
+
+    for (uint256 _i = 0; _i < _count; _i++) {
+      _result[_i] = _proposals[_id][_i];
+    }
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function proposalState(uint256 _id, uint256 _proposalId) external view override returns (ProposalState _state) {
+    Fund storage _fund = _funds[_id];
+    if (_proposalId >= _fund.proposalCount) revert ProposalNotFound();
+
+    return _proposalState(_proposals[_id][_proposalId], _fund.votingPeriod);
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function isExecutable(uint256 _id, uint256 _proposalId) external view override returns (bool _executable) {
+    Fund storage _fund = _funds[_id];
+    if (_proposalId >= _fund.proposalCount) return false;
+
+    Proposal storage _proposal = _proposals[_id][_proposalId];
+    return
+      _proposalState(_proposal, _fund.votingPeriod) == ProposalState.Passed && _fund.poolBalance >= _proposal.amount;
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function previewWithdraw(uint256 _id, address _member) external view override returns (uint256 _amount) {
+    Fund storage _fund = _funds[_id];
+    if (_fund.totalShares == 0) return 0;
+
+    return (sharesOf[_id][_member] * _fund.poolBalance) / _fund.totalShares;
+  }
+
+  /// @inheritdoc ICollectiveFundCircles
+  function isTokenAllowed(address _token) external view override returns (bool _allowed) {
+    return allowedTokens[_token];
+  }
+
+  /**
+   * @dev Compute the lifecycle state of a proposal — a pure function of storage + time.
+   *      Evaluation order (first match wins):
+   *        1. executed -> Executed (terminal)
+   *        2. threshold reached, now <= executionDeadline -> Passed
+   *        3. threshold reached, now > executionDeadline -> Expired (terminal)
+   *        4. now > voteDeadline -> Defeated (terminal)
+   *        5. threshold mathematically unreachable -> Defeated
+   *        6. otherwise -> Active
+   *      where voteDeadline = createdAt + votingPeriod and executionDeadline = createdAt +
+   *      2 * votingPeriod (self-scaling execution grace of one extra voting period).
+   * @param _proposal The proposal
+   * @param _votingPeriod The fund's voting period
+   * @return _state The proposal state
+   */
+  function _proposalState(
+    Proposal storage _proposal,
+    uint256 _votingPeriod
+  ) internal view returns (ProposalState _state) {
+    if (_proposal.executed) return ProposalState.Executed;
+
+    if (_proposal.yesVotes >= _proposal.requiredYes) {
+      return block.timestamp <= _proposal.createdAt + 2 * _votingPeriod ? ProposalState.Passed : ProposalState.Expired;
+    }
+    if (block.timestamp > _proposal.createdAt + _votingPeriod) return ProposalState.Defeated;
+    // Early mathematical defeat: even if every remaining eligible voter votes yes,
+    // yesVotes + (electorate - yesVotes - noVotes) == electorate - noVotes < requiredYes.
+    if (_proposal.electorate - _proposal.noVotes < _proposal.requiredYes) return ProposalState.Defeated;
+
+    return ProposalState.Active;
+  }
+
+  /**
+   * @dev Computes the EIP-712 hash for an invite
+   * @notice _INVITE_TYPEHASH is keccak256('Invite(uint256 id,uint256 nonce)')
+   */
+  function _hashInvite(uint256 _id, uint256 _nonce) private view returns (bytes32) {
+    bytes32 _structHash = keccak256(abi.encode(_INVITE_TYPEHASH, _id, _nonce));
+    return _hashTypedDataV4(_structHash);
+  }
+}

--- a/src/contracts/GoalSavingCircles.sol
+++ b/src/contracts/GoalSavingCircles.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {ReentrancyGuardUpgradeable} from '@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol';
+import {EIP712Upgradeable} from '@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {ECDSA} from '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+
+import {IGoalSavingCircles} from 'interfaces/IGoalSavingCircles.sol';
+
+using SafeERC20 for IERC20;
+
+/**
+ * @title Goal Saving Circles
+ * @notice Goal-based group savings: members deposit flexible amounts toward a target before a
+ *         deadline. Funds are locked while funding (the commitment device). On success the pot
+ *         is released to a beneficiary, or — with no beneficiary — each member reclaims exactly
+ *         their own contributions. On failure or cancellation everyone is refunded in full.
+ * @dev All accounting is exact addition/subtraction of caller-supplied amounts: no division, no
+ *      interest, no credit. See docs/goal-saving-circles.md for the design rationale.
+ * @author Breadchain Collective
+ */
+contract GoalSavingCircles is IGoalSavingCircles, ReentrancyGuardUpgradeable, OwnableUpgradeable, EIP712Upgradeable {
+  string private constant _EIP712_NAME = 'StacksInvite';
+  string private constant _EIP712_VERSION = '1';
+  bytes32 private constant _INVITE_TYPEHASH = keccak256('Invite(uint256 id,uint256 nonce)');
+
+  /// @inheritdoc IGoalSavingCircles
+  uint256 public nextId;
+  mapping(address token => bool status) public allowedTokens;
+  mapping(uint256 id => Goal goal) public goals;
+  /// @inheritdoc IGoalSavingCircles
+  mapping(uint256 id => uint256 amount) public totalDeposited;
+  /// @inheritdoc IGoalSavingCircles
+  mapping(uint256 id => mapping(address member => uint256 amount)) public contributions;
+  /// @inheritdoc IGoalSavingCircles
+  mapping(uint256 id => mapping(address member => bool status)) public isMember;
+  mapping(uint256 id => address[] members) public goalMembers;
+  mapping(address member => uint256[] ids) public memberGoals;
+  /// @inheritdoc IGoalSavingCircles
+  mapping(uint256 id => mapping(uint256 nonce => bool used)) public usedNonces;
+  /// @inheritdoc IGoalSavingCircles
+  mapping(uint256 id => bool status) public goalReached;
+  /// @inheritdoc IGoalSavingCircles
+  mapping(uint256 id => bool status) public cancelled;
+  /// @inheritdoc IGoalSavingCircles
+  mapping(uint256 id => bool status) public released;
+
+  /// @dev Requires the goal exists
+  modifier onlyExisting(uint256 _id) {
+    if (!_exists(_id)) revert GoalNotFound();
+    _;
+  }
+
+  /// @dev Requires the goal is open for deposits and joins: not cancelled, not released, and
+  ///      strictly before the deadline. Does NOT check goalReached — overshoot is allowed.
+  modifier onlyOpen(uint256 _id) {
+    if (cancelled[_id] || released[_id] || block.timestamp >= goals[_id].deadline) revert GoalNotOpen();
+    _;
+  }
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function initialize(address _owner) external override initializer {
+    __EIP712_init(_EIP712_NAME, _EIP712_VERSION);
+    __Ownable_init(_owner);
+    __ReentrancyGuard_init();
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function setTokenAllowed(address _token, bool _allowed) external override onlyOwner {
+    allowedTokens[_token] = _allowed;
+
+    emit TokenAllowed(_token, _allowed);
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function create(
+    address _token,
+    uint256 _goalAmount,
+    uint256 _deadline,
+    address _beneficiary
+  ) external override returns (uint256 _id) {
+    if (!allowedTokens[_token]) revert TokenNotAllowed();
+    if (_goalAmount == 0) revert InvalidGoalAmount();
+    if (_deadline <= block.timestamp) revert InvalidDeadline();
+
+    _id = nextId++;
+
+    goals[_id] =
+      Goal({owner: msg.sender, token: _token, beneficiary: _beneficiary, goalAmount: _goalAmount, deadline: _deadline});
+    _addMember(_id, msg.sender);
+
+    emit GoalCreated(_id, msg.sender, _token, _goalAmount, _deadline, _beneficiary);
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function redeemInvite(
+    uint256 _id,
+    uint256 _nonce,
+    bytes calldata _signature
+  ) external override nonReentrant onlyExisting(_id) onlyOpen(_id) {
+    if (usedNonces[_id][_nonce]) revert InviteAlreadyUsed();
+    if (isMember[_id][msg.sender]) revert AlreadyMember();
+
+    bytes32 _digest = _hashInvite(_id, _nonce);
+    address _signer = ECDSA.recover(_digest, _signature);
+    if (_signer != goals[_id].owner) revert InvalidSigner();
+
+    usedNonces[_id][_nonce] = true;
+    _addMember(_id, msg.sender);
+
+    emit InviteRedeemed(_id, msg.sender);
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function deposit(uint256 _id, uint256 _value) external override nonReentrant {
+    _deposit(_id, msg.sender, _value);
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function depositFor(uint256 _id, address _member, uint256 _value) external override nonReentrant {
+    _deposit(_id, _member, _value);
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function withdraw(uint256 _id) external override nonReentrant {
+    GoalState _state = goalState(_id);
+    bool _refundable = _state == GoalState.Failed || _state == GoalState.Cancelled
+      || (_state == GoalState.Funded && goals[_id].beneficiary == address(0));
+    if (!_refundable) revert NotWithdrawable();
+
+    uint256 _amount = contributions[_id][msg.sender];
+    if (_amount == 0) revert NothingToWithdraw();
+
+    contributions[_id][msg.sender] = 0;
+    totalDeposited[_id] -= _amount;
+
+    IERC20(goals[_id].token).safeTransfer(msg.sender, _amount);
+
+    emit FundsWithdrawn(_id, msg.sender, _amount);
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function release(uint256 _id) external override nonReentrant {
+    address _beneficiary = goals[_id].beneficiary;
+    if (goalState(_id) != GoalState.Funded || _beneficiary == address(0)) revert NotReleasable();
+
+    released[_id] = true;
+    uint256 _amount = totalDeposited[_id];
+    totalDeposited[_id] = 0;
+
+    IERC20(goals[_id].token).safeTransfer(_beneficiary, _amount);
+
+    emit GoalReleased(_id, _beneficiary, _amount);
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function cancel(uint256 _id) external override nonReentrant onlyExisting(_id) {
+    if (msg.sender != goals[_id].owner) revert NotOwner();
+    if (goalState(_id) != GoalState.Funding) revert NotCancellable();
+
+    cancelled[_id] = true;
+
+    emit GoalCancelled(_id);
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function getGoal(uint256 _id) external view override onlyExisting(_id) returns (Goal memory _goal) {
+    _goal = goals[_id];
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function getGoalMembers(uint256 _id) external view override returns (address[] memory _members) {
+    _members = goalMembers[_id];
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function getMemberGoals(address _member) external view override returns (uint256[] memory _ids) {
+    _ids = memberGoals[_member];
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function getMemberContributions(uint256 _id)
+    external
+    view
+    override
+    returns (address[] memory _members, uint256[] memory _amounts)
+  {
+    _members = goalMembers[_id];
+    _amounts = new uint256[](_members.length);
+
+    for (uint256 _i = 0; _i < _members.length; _i++) {
+      _amounts[_i] = contributions[_id][_members[_i]];
+    }
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function isTokenAllowed(address _token) external view override returns (bool _allowed) {
+    _allowed = allowedTokens[_token];
+  }
+
+  /// @inheritdoc IGoalSavingCircles
+  function goalState(uint256 _id) public view override onlyExisting(_id) returns (GoalState _state) {
+    if (cancelled[_id]) return GoalState.Cancelled;
+    if (released[_id]) return GoalState.Released;
+    if (goalReached[_id]) return GoalState.Funded;
+    if (block.timestamp >= goals[_id].deadline) return GoalState.Failed;
+    return GoalState.Funding;
+  }
+
+  /**
+   * @dev Credit a deposit to `_member`, pulling the tokens from `msg.sender`. Latches
+   *      `goalReached` (and emits {GoalReached} exactly once) when the pot first meets the goal.
+   * @param _id The id of the goal.
+   * @param _member The member to credit.
+   * @param _value The amount to deposit.
+   */
+  function _deposit(uint256 _id, address _member, uint256 _value) internal onlyExisting(_id) onlyOpen(_id) {
+    if (!isMember[_id][_member]) revert NotMember();
+    if (_value == 0) revert InvalidDeposit();
+
+    contributions[_id][_member] += _value;
+    totalDeposited[_id] += _value;
+
+    if (!goalReached[_id] && totalDeposited[_id] >= goals[_id].goalAmount) {
+      goalReached[_id] = true;
+      emit GoalReached(_id, totalDeposited[_id]);
+    }
+
+    IERC20(goals[_id].token).safeTransferFrom(msg.sender, address(this), _value);
+
+    emit FundsDeposited(_id, _member, _value);
+  }
+
+  /**
+   * @dev Add `_member` to the goal roster: flag, member list, and reverse index.
+   * @param _id The id of the goal.
+   * @param _member The member to add.
+   */
+  function _addMember(uint256 _id, address _member) internal {
+    isMember[_id][_member] = true;
+    goalMembers[_id].push(_member);
+    memberGoals[_member].push(_id);
+  }
+
+  /**
+   * @dev Return whether a goal exists (goals[id].owner is set at create and never cleared).
+   * @param _id The id of the goal.
+   * @return _existing Whether the goal exists.
+   */
+  function _exists(uint256 _id) internal view returns (bool _existing) {
+    _existing = goals[_id].owner != address(0);
+  }
+
+  /**
+   * @dev Computes the EIP-712 hash for an invite
+   * @notice _INVITE_TYPEHASH is keccak256('Invite(uint256 id,uint256 nonce)')
+   */
+  function _hashInvite(uint256 _id, uint256 _nonce) private view returns (bytes32 _digest) {
+    bytes32 _structHash = keccak256(abi.encode(_INVITE_TYPEHASH, _id, _nonce));
+    _digest = _hashTypedDataV4(_structHash);
+  }
+}

--- a/src/interfaces/IAccumulatingSavingCircles.sol
+++ b/src/interfaces/IAccumulatingSavingCircles.sol
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title IAccumulatingSavingCircles
+ * @notice Interface for an Accumulating Savings and Credit Association (ASCA): members deposit
+ *         flexible amounts into a shared pool, earn a credit line proportional to their own
+ *         savings, borrow against it, and repay within a fixed number of periods with optional
+ *         simple interest. Interest is streamed pro-rata to savers via a MasterChef-style
+ *         per-share accumulator. Loans are always fully self-collateralized by the borrower's
+ *         own savings (borrowLimitBps <= 10_000), so no honest member can lose principal.
+ */
+interface IAccumulatingSavingCircles {
+  // =======================
+  // STRUCTS
+  // =======================
+
+  /**
+   * @notice Configuration and lifecycle of a fund.
+   * @param owner The fund organizer: signs EIP-712 invites and may deactivate the fund.
+   * @param token The ERC20 token of the fund (must be allowlisted at creation).
+   * @param borrowLimitBps Credit line in basis points of a member's savings; <= 10_000 (100%).
+   * @param interestRateBps Simple interest per whole period on outstanding principal, in bps; <= 10_000.
+   * @param repaymentPeriods Number of periods after which a loan is due; in [1, 1_000]. Interest
+   *        accrual is capped at this many periods.
+   * @param periodLength Seconds per period; in [1, 365 days].
+   * @param deactivated Whether the organizer has irreversibly frozen deposits, borrows and invites.
+   */
+  struct Fund {
+    address owner;
+    address token;
+    uint256 borrowLimitBps;
+    uint256 interestRateBps;
+    uint256 repaymentPeriods;
+    uint256 periodLength;
+    bool deactivated;
+  }
+
+  /**
+   * @notice A member's single open loan position.
+   * @param principal Outstanding principal; 0 means no open loan.
+   * @param interestOwed Accrued, unpaid interest as of the last accrual checkpoint.
+   * @param periodsAccrued Whole periods already accounted in interestOwed (capped at repaymentPeriods).
+   * @param startTime Timestamp of the borrow; due date = startTime + repaymentPeriods * periodLength.
+   */
+  struct Loan {
+    uint256 principal;
+    uint256 interestOwed;
+    uint256 periodsAccrued;
+    uint256 startTime;
+  }
+
+  // =======================
+  // EVENTS
+  // =======================
+
+  /// @notice Emitted when a token is allowed or disallowed by the contract owner.
+  event TokenAllowed(address indexed token, bool indexed allowed);
+
+  /**
+   * @notice Emitted when a fund is created.
+   * @param id The fund id.
+   * @param owner The organizer (msg.sender at create).
+   * @param token The fund token.
+   * @param borrowLimitBps The credit-line percentage in bps.
+   * @param interestRateBps The per-period simple interest rate in bps.
+   * @param repaymentPeriods The loan tenor in periods.
+   * @param periodLength Seconds per period.
+   */
+  event FundCreated(
+    uint256 indexed id,
+    address indexed owner,
+    address indexed token,
+    uint256 borrowLimitBps,
+    uint256 interestRateBps,
+    uint256 repaymentPeriods,
+    uint256 periodLength
+  );
+
+  /// @notice Emitted when an invite is redeemed and the redeemer becomes a member.
+  event InviteRedeemed(uint256 indexed id, address indexed redeemer);
+
+  /// @notice Emitted when savings are deposited for a member.
+  event SavingsDeposited(uint256 indexed id, address indexed member, uint256 amount);
+
+  /// @notice Emitted when a member withdraws savings.
+  event SavingsWithdrawn(uint256 indexed id, address indexed member, uint256 amount);
+
+  /**
+   * @notice Emitted when a member opens a loan.
+   * @param id The fund id.
+   * @param member The borrower.
+   * @param amount The principal borrowed.
+   * @param dueDate Timestamp after which the loan is liquidatable.
+   */
+  event Borrowed(uint256 indexed id, address indexed member, uint256 amount, uint256 dueDate);
+
+  /**
+   * @notice Emitted when a member repays; interest is settled before principal.
+   * @param id The fund id.
+   * @param member The borrower.
+   * @param interestPaid Portion of the payment applied to accrued interest.
+   * @param principalPaid Portion of the payment applied to principal.
+   */
+  event Repaid(uint256 indexed id, address indexed member, uint256 interestPaid, uint256 principalPaid);
+
+  /**
+   * @notice Emitted when received or seized interest is distributed to savers via the accumulator.
+   * @param id The fund id.
+   * @param amount The interest amount distributed (floor-rounded dust stays in the pool).
+   */
+  event InterestDistributed(uint256 indexed id, uint256 amount);
+
+  /// @notice Emitted when a member claims their settled + pending interest.
+  event InterestClaimed(uint256 indexed id, address indexed member, uint256 amount);
+
+  /**
+   * @notice Emitted when an overdue loan is liquidated by seizing the borrower's savings.
+   * @param id The fund id.
+   * @param member The liquidated borrower.
+   * @param principalSeized Savings seized to extinguish the principal (always == principal).
+   * @param interestSeized Savings seized and distributed to savers as interest (may be < interestOwed).
+   */
+  event Liquidated(uint256 indexed id, address indexed member, uint256 principalSeized, uint256 interestSeized);
+
+  /// @notice Emitted when the organizer deactivates a fund.
+  event FundDeactivated(uint256 indexed id);
+
+  // =======================
+  // ERRORS
+  // =======================
+
+  /// @notice Thrown when the token is not on the allowlist.
+  error TokenNotAllowed();
+  /// @notice Thrown when a fund creation parameter is out of range.
+  error InvalidParameters();
+  /// @notice Thrown when acting on a fund id that does not exist.
+  error FundNotFound();
+  /// @notice Thrown when depositing, borrowing or joining a deactivated fund.
+  error FundNotActive();
+  /// @notice Thrown when a fund-owner-only action is called by someone else.
+  error NotFundOwner();
+  /// @notice Thrown when the subject is not a member of the fund.
+  error NotMember();
+  /// @notice Thrown when the caller is already a member of the fund.
+  error AlreadyMember();
+  /// @notice Thrown when an invite signature does not recover to the fund owner.
+  error InvalidSigner();
+  /// @notice Thrown when an invite nonce has already been used.
+  error InviteAlreadyUsed();
+  /// @notice Thrown when an amount parameter is zero.
+  error ZeroAmount();
+  /// @notice Thrown when a withdrawal exceeds the member's savings.
+  error InsufficientSavings();
+  /// @notice Thrown when the pool does not hold enough cash for the transfer.
+  error InsufficientLiquidity();
+  /// @notice Thrown when a borrow would exceed the member's credit line.
+  error ExceedsCreditLine();
+  /// @notice Thrown when borrowing while a loan is still open.
+  error OutstandingLoan();
+  /// @notice Thrown when repaying or liquidating with no open loan.
+  error NoActiveLoan();
+  /// @notice Thrown when a withdrawal would leave the debt under-collateralized.
+  error InsufficientCollateral();
+  /// @notice Thrown when liquidating a loan that is not overdue.
+  error NotLiquidatable();
+  /// @notice Thrown when claiming interest with nothing to claim.
+  error NothingToClaim();
+
+  // =======================
+  // ADMIN
+  // =======================
+
+  /**
+   * @notice Initialize the upgradeable contract.
+   * @param owner The contract admin that manages the token allowlist.
+   */
+  function initialize(address owner) external;
+
+  /**
+   * @notice Allow or disallow a token for use in new funds.
+   * @dev Weird tokens (fee-on-transfer, rebasing, non-standard decimals, ERC777 hooks) are out of
+   *      scope by policy: this allowlist is the control.
+   * @param token The token address.
+   * @param allowed Whether the token is allowed.
+   */
+  function setTokenAllowed(address token, bool allowed) external;
+
+  // =======================
+  // LIFECYCLE
+  // =======================
+
+  /**
+   * @notice Create a fund. The caller becomes the fund owner (organizer) and its first member.
+   * @param token The ERC20 token (must be allowlisted).
+   * @param borrowLimitBps Credit line in bps of a member's savings (0..10_000; 0 = savings-only fund).
+   * @param interestRateBps Simple interest per period in bps (0..10_000).
+   * @param repaymentPeriods Loan tenor in periods (1..1_000).
+   * @param periodLength Seconds per period (1..365 days).
+   * @return id The id of the new fund.
+   */
+  function create(
+    address token,
+    uint256 borrowLimitBps,
+    uint256 interestRateBps,
+    uint256 repaymentPeriods,
+    uint256 periodLength
+  ) external returns (uint256 id);
+
+  /**
+   * @notice Join a fund by redeeming an EIP-712 invite signed by the fund owner.
+   * @dev Same 'StacksInvite' domain and Invite(uint256 id,uint256 nonce) typehash as SavingCircles.
+   *      Joining is allowed any time while the fund is active (continuous membership).
+   * @param id The fund id.
+   * @param nonce Unique invite nonce.
+   * @param signature The fund owner's EIP-712 signature.
+   */
+  function redeemInvite(uint256 id, uint256 nonce, bytes calldata signature) external;
+
+  /**
+   * @notice Irreversibly deactivate a fund: blocks deposit/depositFor/borrow/redeemInvite.
+   *         withdraw, repay, claimInterest and liquidate remain available so everyone can exit.
+   * @dev Only the fund owner.
+   * @param id The fund id.
+   */
+  function deactivate(uint256 id) external;
+
+  // =======================
+  // SAVINGS
+  // =======================
+
+  /**
+   * @notice Deposit any amount of savings for the caller.
+   * @param id The fund id.
+   * @param amount The amount to deposit (> 0).
+   */
+  function deposit(uint256 id, uint256 amount) external;
+
+  /**
+   * @notice Deposit savings for another member, funded by the caller.
+   * @param id The fund id.
+   * @param member The member to credit (must be a member).
+   * @param amount The amount to deposit (> 0).
+   */
+  function depositFor(uint256 id, address member, uint256 amount) external;
+
+  /**
+   * @notice Withdraw savings. Reverts if the remaining savings would no longer collateralize the
+   *         caller's outstanding debt (principal + accrued interest) at borrowLimitBps, or if the
+   *         pool lacks cash.
+   * @param id The fund id.
+   * @param amount The amount to withdraw (> 0).
+   */
+  function withdraw(uint256 id, uint256 amount) external;
+
+  /**
+   * @notice Claim all of the caller's settled and pending interest.
+   * @dev Reverts with InsufficientLiquidity if the pool cash is currently lent out; liquidity is
+   *      guaranteed to return by repayment or permissionless liquidation at the due date.
+   * @param id The fund id.
+   */
+  function claimInterest(uint256 id) external;
+
+  // =======================
+  // CREDIT
+  // =======================
+
+  /**
+   * @notice Open a loan. Only one loan may be open at a time; the previous loan must be fully
+   *         repaid (or liquidated) first. amount must satisfy
+   *         amount * 10_000 <= borrowLimitBps * savings, and the pool must hold the cash.
+   * @param id The fund id.
+   * @param amount The principal to borrow (> 0).
+   */
+  function borrow(uint256 id, uint256 amount) external;
+
+  /**
+   * @notice Repay the caller's loan. Payment settles accrued interest first, then principal; any
+   *         amount above the total debt is not pulled. Interest received is immediately
+   *         distributed pro-rata to savers via the accumulator.
+   * @dev Interest accrues per whole elapsed period only: a loan repaid within its first period
+   *      owes zero interest.
+   * @param id The fund id.
+   * @param amount The maximum amount to pay (> 0).
+   */
+  function repay(uint256 id, uint256 amount) external;
+
+  /**
+   * @notice Liquidate an overdue loan by seizing the borrower's savings. Permissionless.
+   * @dev Overdue = block.timestamp >= startTime + repaymentPeriods * periodLength and principal > 0.
+   *      Seizes exactly principal (always covered) plus min(interestOwed, remaining savings) of
+   *      interest, which is distributed to savers; if no savings shares would remain in the fund,
+   *      the interest portion is not seized. Moves no tokens (pure ledger reallocation).
+   * @param id The fund id.
+   * @param member The borrower to liquidate.
+   */
+  function liquidate(uint256 id, address member) external;
+
+  // =======================
+  // VIEWS
+  // =======================
+
+  /**
+   * @notice Returns whether a token is allowed.
+   * @param token The token address.
+   * @return allowed Whether the token is allowed.
+   */
+  function isTokenAllowed(address token) external view returns (bool allowed);
+
+  /**
+   * @notice Returns the id that will be assigned to the next fund.
+   * @return id The next fund id.
+   */
+  function nextId() external view returns (uint256 id);
+
+  /**
+   * @notice Returns a fund's configuration and lifecycle flag.
+   * @dev Reverts with FundNotFound for nonexistent ids.
+   * @param id The fund id.
+   * @return fund The fund.
+   */
+  function getFund(uint256 id) external view returns (Fund memory fund);
+
+  /**
+   * @notice Returns the ordered member roster of a fund.
+   * @param id The fund id.
+   * @return members The roster (append-only; members are never removed).
+   */
+  function getFundMembers(uint256 id) external view returns (address[] memory members);
+
+  /**
+   * @notice Returns every fund id an address has joined.
+   * @param member The member address.
+   * @return ids The fund ids.
+   */
+  function getMemberFunds(address member) external view returns (uint256[] memory ids);
+
+  /**
+   * @notice Returns the fund's aggregate balances.
+   * @param id The fund id.
+   * @return totalSavings_ Sum of all members' savings.
+   * @return totalBorrowed_ Sum of all outstanding loan principal.
+   * @return poolCash_ The fund's internal cash ledger.
+   */
+  function getFundBalances(uint256 id)
+    external
+    view
+    returns (uint256 totalSavings_, uint256 totalBorrowed_, uint256 poolCash_);
+
+  /**
+   * @notice Returns a member's loan with interest accrued up to now (capped at repaymentPeriods).
+   * @param id The fund id.
+   * @param member The member.
+   * @return loan The loan (principal == 0 means none).
+   * @return dueDate The due date (0 if no loan).
+   */
+  function getLoan(uint256 id, address member) external view returns (Loan memory loan, uint256 dueDate);
+
+  /**
+   * @notice Returns a member's credit line: borrowLimitBps * savings / 10_000 (floor).
+   * @param id The fund id.
+   * @param member The member.
+   * @return amount The credit line.
+   */
+  function creditLineOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns the largest amount the member could borrow right now:
+   *         0 if a loan is open or the fund is deactivated, else min(creditLine, poolCash).
+   * @param id The fund id.
+   * @param member The member.
+   * @return amount The maximum borrowable amount.
+   */
+  function maxBorrowableOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns a member's unclaimed interest: interestCredit + unsettled accumulator share.
+   * @param id The fund id.
+   * @param member The member.
+   * @return amount The unclaimed interest.
+   */
+  function pendingInterestOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns a member's total withdrawable value: savings + pendingInterest (before
+   *         collateral and liquidity guards).
+   * @param id The fund id.
+   * @param member The member.
+   * @return amount The total withdrawable value.
+   */
+  function withdrawableOf(uint256 id, address member) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns whether a member's loan is currently liquidatable.
+   * @param id The fund id.
+   * @param member The member.
+   * @return liquidatable Whether the loan is overdue and open.
+   */
+  function isLiquidatable(uint256 id, address member) external view returns (bool liquidatable);
+
+  // =======================
+  // PUBLIC STORAGE GETTERS
+  // =======================
+
+  /**
+   * @notice Returns a member's savings principal in a fund (collateral base and accumulator shares).
+   * @param id The fund id.
+   * @param member The member.
+   * @return amount The savings amount.
+   */
+  function savings(uint256 id, address member) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns interest already settled to a member (claimable via claimInterest), not yet transferred.
+   * @param id The fund id.
+   * @param member The member.
+   * @return amount The settled interest credit.
+   */
+  function interestCredit(uint256 id, address member) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns the sum of all members' savings in a fund (the accumulator share supply).
+   * @param id The fund id.
+   * @return amount The total savings.
+   */
+  function totalSavings(uint256 id) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns the sum of all outstanding loan principal in a fund.
+   * @param id The fund id.
+   * @return amount The total borrowed principal.
+   */
+  function totalBorrowed(uint256 id) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns the fund's internal cash ledger: tokens received minus tokens sent for the fund.
+   * @param id The fund id.
+   * @return amount The pool cash.
+   */
+  function poolCash(uint256 id) external view returns (uint256 amount);
+
+  /**
+   * @notice Returns the cumulative distributed interest per savings share, scaled by 1e18.
+   * @param id The fund id.
+   * @return acc The accumulator value (monotone non-decreasing).
+   */
+  function accInterestPerShare(uint256 id) external view returns (uint256 acc);
+
+  /**
+   * @notice Returns whether an address is a member of a fund.
+   * @param id The fund id.
+   * @param member The address.
+   * @return status Whether the address is a member.
+   */
+  function isMember(uint256 id, address member) external view returns (bool status);
+
+  /**
+   * @notice Returns whether an EIP-712 invite nonce has been spent for a fund.
+   * @param id The fund id.
+   * @param nonce The invite nonce.
+   * @return used Whether the nonce has been used.
+   */
+  function usedNonces(uint256 id, uint256 nonce) external view returns (bool used);
+
+  /**
+   * @notice Returns whether a token is on the admin allowlist.
+   * @param token The token address.
+   * @return allowed Whether the token is allowed.
+   */
+  function allowedTokens(address token) external view returns (bool allowed);
+}

--- a/src/interfaces/ICollectiveFundCircles.sol
+++ b/src/interfaces/ICollectiveFundCircles.sol
@@ -1,0 +1,496 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title ICollectiveFundCircles
+ * @notice A communal savings pot: members deposit flexible amounts, may rage-quit anytime for a
+ *         pro-rata share of the remaining pool, and spend the pool collectively via
+ *         one-member-one-vote disbursement proposals with a snapshotted electorate.
+ * @dev Singleton registry: many funds per contract keyed by uint256 id. White-label friendly —
+ *      each fund stores its display name on-chain; a frontend resolves a fund from `?f=<id>`
+ *      with a single getFund call. Membership is by fund-owner-signed EIP-712 invite
+ *      (domain 'StacksInvite', identical to SavingCircles). Principal-spending by design:
+ *      an executed proposal dilutes every shareholder pro-rata (see withdraw).
+ */
+interface ICollectiveFundCircles {
+  /**
+   * @notice Lifecycle state of a disbursement proposal (pure function of storage + time).
+   * @dev Active = 0 (voting open, threshold not yet reached, still mathematically reachable),
+   *      Defeated = 1 (voting closed without reaching threshold, or threshold unreachable),
+   *      Passed = 2 (threshold reached, executable, execution window open),
+   *      Executed = 3 (funds transferred),
+   *      Expired = 4 (threshold reached but nobody executed before the execution deadline).
+   */
+  enum ProposalState {
+    Active,
+    Defeated,
+    Passed,
+    Executed,
+    Expired
+  }
+
+  /**
+   * @notice A collective fund.
+   * @param owner The fund organizer: signs invites and may rename the fund
+   * @param token The allowlisted ERC20 the fund saves and spends
+   * @param votingPeriod Seconds each proposal accepts votes
+   * @param approvalThresholdBps Yes-votes required, in basis points of the snapshotted electorate
+   * @param totalShares Sum of all member shares (shares mint 1:1 with deposited tokens)
+   * @param poolBalance Tokens currently held by this fund (internal accounting)
+   * @param proposalCount Number of proposals ever created for this fund
+   * @param name On-chain display name for white-label frontends
+   */
+  struct Fund {
+    address owner;
+    address token;
+    uint256 votingPeriod;
+    uint256 approvalThresholdBps;
+    uint256 totalShares;
+    uint256 poolBalance;
+    uint256 proposalCount;
+    string name;
+  }
+
+  /**
+   * @notice A disbursement proposal.
+   * @param proposer The member who created the proposal (auto-votes yes)
+   * @param recipient The address that receives the funds on execution
+   * @param amount The token amount to transfer on execution (checked against poolBalance at
+   *        execute time only — proposals do NOT reserve funds)
+   * @param createdAt Creation timestamp; voting closes at createdAt + votingPeriod, execution
+   *        closes at createdAt + 2 * votingPeriod
+   * @param electorate Member count snapshotted at creation (members joining later cannot vote)
+   * @param requiredYes Snapshotted ceil(electorate * approvalThresholdBps / 10_000), always >= 1
+   * @param yesVotes Yes votes cast
+   * @param noVotes No votes cast
+   * @param executed Whether the disbursement has been executed
+   * @param description Human-readable rationale, stored on-chain for backend-free frontends
+   */
+  struct Proposal {
+    address proposer;
+    address recipient;
+    uint256 amount;
+    uint256 createdAt;
+    uint256 electorate;
+    uint256 requiredYes;
+    uint256 yesVotes;
+    uint256 noVotes;
+    bool executed;
+    string description;
+  }
+
+  // =======================
+  // EVENTS
+  // =======================
+
+  /**
+   * @notice Emitted when a token is allowed or disallowed by the contract owner
+   * @param token The address of the token
+   * @param allowed Whether the token is allowed
+   */
+  event TokenAllowed(address indexed token, bool indexed allowed);
+
+  /**
+   * @notice Emitted when a fund is created
+   * @param id The ID of the fund
+   * @param owner The fund organizer
+   * @param token The fund's token
+   * @param name The fund's display name
+   * @param votingPeriod The proposal voting period in seconds
+   * @param approvalThresholdBps The approval threshold in basis points of the electorate
+   */
+  event FundCreated(
+    uint256 indexed id,
+    address indexed owner,
+    address indexed token,
+    string name,
+    uint256 votingPeriod,
+    uint256 approvalThresholdBps
+  );
+
+  /**
+   * @notice Emitted when an invite is successfully redeemed (identical shape to SavingCircles)
+   * @param id The ID of the fund
+   * @param redeemer The new member
+   */
+  event InviteRedeemed(uint256 indexed id, address indexed redeemer);
+
+  /**
+   * @notice Emitted when a member deposits into a fund (shares minted 1:1 with amount)
+   * @param id The ID of the fund
+   * @param member The depositing member
+   * @param amount The token amount deposited (== shares minted)
+   */
+  event FundsDeposited(uint256 indexed id, address indexed member, uint256 amount);
+
+  /**
+   * @notice Emitted when anyone donates to a fund (no shares minted)
+   * @param id The ID of the fund
+   * @param donor The donor
+   * @param amount The token amount donated
+   */
+  event FundsDonated(uint256 indexed id, address indexed donor, uint256 amount);
+
+  /**
+   * @notice Emitted when a member burns shares for their pro-rata payout
+   * @param id The ID of the fund
+   * @param member The withdrawing member
+   * @param shares The shares burned
+   * @param amount The tokens paid out (floor(shares * poolBalance / totalShares))
+   */
+  event FundsWithdrawn(uint256 indexed id, address indexed member, uint256 shares, uint256 amount);
+
+  /**
+   * @notice Emitted when the fund owner renames the fund
+   * @param id The ID of the fund
+   * @param name The new display name
+   */
+  event FundNameUpdated(uint256 indexed id, string name);
+
+  /**
+   * @notice Emitted when a proposal is created
+   * @param id The ID of the fund
+   * @param proposalId The per-fund proposal ID
+   * @param proposer The proposing member
+   * @param recipient The disbursement recipient
+   * @param amount The disbursement amount
+   * @param description The proposal rationale
+   */
+  event ProposalCreated(
+    uint256 indexed id,
+    uint256 indexed proposalId,
+    address indexed proposer,
+    address recipient,
+    uint256 amount,
+    string description
+  );
+
+  /**
+   * @notice Emitted when a member casts a vote
+   * @param id The ID of the fund
+   * @param proposalId The proposal ID
+   * @param voter The voting member
+   * @param support True for yes, false for no
+   */
+  event VoteCast(uint256 indexed id, uint256 indexed proposalId, address indexed voter, bool support);
+
+  /**
+   * @notice Emitted when a passed proposal is executed
+   * @param id The ID of the fund
+   * @param proposalId The proposal ID
+   * @param recipient The recipient paid
+   * @param amount The amount transferred
+   */
+  event ProposalExecuted(uint256 indexed id, uint256 indexed proposalId, address recipient, uint256 amount);
+
+  // =======================
+  // ERRORS
+  // =======================
+
+  /// @notice Thrown when a token is not on the allowlist
+  error TokenNotAllowed();
+  /// @notice Thrown when acting on a fund id that does not exist
+  error FundNotFound();
+  /// @notice Thrown when creating a fund with a zero owner address
+  error InvalidFundOwner();
+  /// @notice Thrown when a fund name is empty
+  error InvalidName();
+  /// @notice Thrown when the voting period is zero or exceeds MAX_VOTING_PERIOD
+  error InvalidVotingPeriod();
+  /// @notice Thrown when the approval threshold is zero or exceeds MAX_BPS
+  error InvalidThreshold();
+  /// @notice Thrown when the caller/subject is not a member of the fund
+  error NotMember();
+  /// @notice Thrown when the caller is already a member of the fund
+  error AlreadyMember();
+  /// @notice Thrown when an invite nonce has already been used
+  error InviteAlreadyUsed();
+  /// @notice Thrown when the signer of an invite is not the fund owner
+  error InvalidSigner();
+  /// @notice Thrown when the caller is not the fund owner
+  error NotFundOwner();
+  /// @notice Thrown when a token or share amount is zero
+  error InvalidAmount();
+  /// @notice Thrown when a member tries to burn more shares than they hold
+  error InsufficientShares();
+  /// @notice Thrown when a proposal recipient is the zero address or the contract itself
+  error InvalidRecipient();
+  /// @notice Thrown when acting on a proposal id that does not exist
+  error ProposalNotFound();
+  /// @notice Thrown when voting after the voting deadline or on an executed proposal
+  error VotingClosed();
+  /// @notice Thrown when a voter joined after the proposal's electorate snapshot
+  error NotEligible();
+  /// @notice Thrown when a member votes twice on the same proposal
+  error AlreadyVoted();
+  /// @notice Thrown when executing a proposal that has not reached its threshold
+  error ProposalNotPassed();
+  /// @notice Thrown when executing an already-executed proposal
+  error ProposalAlreadyExecuted();
+  /// @notice Thrown when executing after the execution deadline
+  error ProposalExpired();
+  /// @notice Thrown when the fund's pool cannot cover the proposal amount at execution time
+  error InsufficientPoolBalance();
+
+  // =======================
+  // FUNCTIONS
+  // =======================
+
+  /**
+   * @notice Initialize the upgradeable contract
+   * @param owner The contract admin (manages the token allowlist)
+   */
+  function initialize(address owner) external;
+
+  /**
+   * @notice Allow or disallow a token for new funds
+   * @dev Owner-only. The allowlist is the control for weird-decimals / fee-on-transfer /
+   *      rebasing tokens, which are out of scope by policy; it gates creation of new funds only.
+   * @param token The address of the token
+   * @param allowed Whether the token is allowed
+   */
+  function setTokenAllowed(address token, bool allowed) external;
+
+  /**
+   * @notice Create a fund. Permissionless; `fundOwner` becomes the first member (index 0).
+   * @param token The allowlisted ERC20 the fund uses
+   * @param fundOwner The organizer who signs invites and may rename the fund
+   * @param name The on-chain display name (non-empty)
+   * @param votingPeriod Proposal voting window in seconds (0 < x <= MAX_VOTING_PERIOD)
+   * @param approvalThresholdBps Approval threshold in bps of the electorate (0 < x <= 10_000)
+   * @return id The ID of the new fund
+   */
+  function create(
+    address token,
+    address fundOwner,
+    string calldata name,
+    uint256 votingPeriod,
+    uint256 approvalThresholdBps
+  ) external returns (uint256 id);
+
+  /**
+   * @notice Join a fund by redeeming an invite signed by the fund owner
+   * @dev EIP-712 domain 'StacksInvite' v1, typehash Invite(uint256 id,uint256 nonce) —
+   *      byte-identical flow to SavingCircles.redeemInvite. Redeemable at any time in the
+   *      fund's life (funds are perpetual; there is no start/active gate).
+   * @param id The ID of the fund
+   * @param nonce Unique nonce for the invite
+   * @param signature The fund owner's EIP-712 signature
+   */
+  function redeemInvite(uint256 id, uint256 nonce, bytes calldata signature) external;
+
+  /**
+   * @notice Deposit tokens into the fund; mints shares 1:1 with the amount
+   * @dev Member-only. If the fund has previously disbursed (poolBalance < totalShares), a new
+   *      deposit is immediately worth less than 1:1 on withdrawal — dilution is shared equally
+   *      per contributed token, not by timing. See withdraw.
+   * @param id The ID of the fund
+   * @param amount The token amount to deposit (> 0)
+   */
+  function deposit(uint256 id, uint256 amount) external;
+
+  /**
+   * @notice Donate tokens to the fund without receiving shares (open to anyone)
+   * @dev Donations raise poolBalance only; they accrue pro-rata to current shareholders and are
+   *      spendable by proposals. ERC20s sent directly to the contract are NOT credited.
+   * @param id The ID of the fund
+   * @param amount The token amount to donate (> 0)
+   */
+  function donate(uint256 id, uint256 amount) external;
+
+  /**
+   * @notice Rage-quit: burn shares for a pro-rata slice of the current pool, anytime
+   * @dev Pays floor(shares * poolBalance / totalShares). After disbursements this is < 1 token
+   *      per share — pro-rata-at-time-of-withdrawal semantics; the contract makes no promise of
+   *      1:1 redemption, only of the pro-rata share of what remains. Burning zero-value shares
+   *      when poolBalance == 0 is permitted (share-base reset). No lock, no delay: rage-quit
+   *      freedom is the trust anchor; an approved proposal does NOT reserve funds against it.
+   * @param id The ID of the fund
+   * @param shares The shares to burn (> 0, <= sharesOf(id, msg.sender))
+   */
+  function withdraw(uint256 id, uint256 shares) external;
+
+  /**
+   * @notice Propose a disbursement from the fund's pool
+   * @dev Member-only. Snapshots electorate = current member count and
+   *      requiredYes = ceil(electorate * approvalThresholdBps / 10_000). The proposer
+   *      automatically votes yes (a single-member fund passes instantly). The amount is NOT
+   *      checked against poolBalance here and is NOT reserved.
+   * @param id The ID of the fund
+   * @param recipient The address to pay (non-zero, not this contract)
+   * @param amount The token amount to pay (> 0)
+   * @param description Human-readable rationale, stored on-chain
+   * @return proposalId The per-fund ID of the new proposal
+   */
+  function propose(
+    uint256 id,
+    address recipient,
+    uint256 amount,
+    string calldata description
+  ) external returns (uint256 proposalId);
+
+  /**
+   * @notice Cast a one-member-one-vote ballot on a proposal
+   * @dev Eligible voters are members whose memberIndex < proposal.electorate (the creation-time
+   *      snapshot). Voting is open until createdAt + votingPeriod and while unexecuted; no
+   *      recasting. No-votes never block execution (threshold counts yes-votes only) but enable
+   *      early mathematical defeat detection in proposalState.
+   * @param id The ID of the fund
+   * @param proposalId The proposal ID
+   * @param support True for yes, false for no
+   */
+  function vote(uint256 id, uint256 proposalId, bool support) external;
+
+  /**
+   * @notice Execute a passed proposal: transfer amount to recipient. Callable by ANYONE.
+   * @dev Executable as soon as yesVotes >= requiredYes (early execution — no need to wait out
+   *      the voting window) and until createdAt + 2 * votingPeriod. Reverts with
+   *      InsufficientPoolBalance if rage-quits (or prior proposals) drained the pool below the
+   *      amount; the proposal stays Passed and may execute later within the window if the pool
+   *      refills.
+   * @param id The ID of the fund
+   * @param proposalId The proposal ID
+   */
+  function execute(uint256 id, uint256 proposalId) external;
+
+  /**
+   * @notice Update the fund's on-chain display name (fund owner only)
+   * @param id The ID of the fund
+   * @param name The new display name (non-empty)
+   */
+  function setFundName(uint256 id, string calldata name) external;
+
+  // =======================
+  // VIEWS
+  // =======================
+
+  /**
+   * @notice Get a fund's full config and accounting (the one-call `?f=<id>` resolver)
+   * @param id The ID of the fund
+   * @return fund The fund
+   */
+  function getFund(uint256 id) external view returns (Fund memory fund);
+
+  /**
+   * @notice Get multiple funds
+   * @param ids The fund IDs
+   * @return result The funds (zeroed entries for nonexistent ids)
+   */
+  function getFunds(uint256[] calldata ids) external view returns (Fund[] memory result);
+
+  /**
+   * @notice Get the ordered member list of a fund
+   * @param id The ID of the fund
+   * @return members The members in join order
+   */
+  function getFundMembers(uint256 id) external view returns (address[] memory members);
+
+  /**
+   * @notice Get all fund IDs an address is a member of
+   * @param member The address
+   * @return ids The fund IDs
+   */
+  function getMemberFunds(address member) external view returns (uint256[] memory ids);
+
+  /**
+   * @notice Check memberships across funds (parity with SavingCircles for app-stacks)
+   * @param member The address
+   * @param ids The fund IDs to check
+   * @return memberships Whether the address is a member of each fund
+   */
+  function checkMemberships(address member, uint256[] calldata ids) external view returns (bool[] memory memberships);
+
+  /**
+   * @notice Get a proposal
+   * @param id The ID of the fund
+   * @param proposalId The proposal ID
+   * @return proposal The proposal
+   */
+  function getProposal(uint256 id, uint256 proposalId) external view returns (Proposal memory proposal);
+
+  /**
+   * @notice Get all proposals of a fund
+   * @param id The ID of the fund
+   * @return result The proposals in creation order
+   */
+  function getProposals(uint256 id) external view returns (Proposal[] memory result);
+
+  /**
+   * @notice Compute the lifecycle state of a proposal (see ProposalState)
+   * @param id The ID of the fund
+   * @param proposalId The proposal ID
+   * @return state The proposal state
+   */
+  function proposalState(uint256 id, uint256 proposalId) external view returns (ProposalState state);
+
+  /**
+   * @notice Whether execute would currently succeed (readiness gate for keepers/frontends)
+   * @param id The ID of the fund
+   * @param proposalId The proposal ID
+   * @return executable True iff state is Passed AND poolBalance >= amount
+   */
+  function isExecutable(uint256 id, uint256 proposalId) external view returns (bool executable);
+
+  /**
+   * @notice A member's current redeemable value if they burned all their shares now
+   * @dev floor(sharesOf * poolBalance / totalShares); 0 when totalShares == 0
+   * @param id The ID of the fund
+   * @param member The member
+   * @return amount The redeemable token amount
+   */
+  function previewWithdraw(uint256 id, address member) external view returns (uint256 amount);
+
+  /**
+   * @notice Get the next ID that will be assigned to a new fund
+   * @return id The next fund ID
+   */
+  function nextId() external view returns (uint256 id);
+
+  /**
+   * @notice Check if a token is allowed
+   * @param token The address of the token
+   * @return allowed Whether the token is allowed
+   */
+  function isTokenAllowed(address token) external view returns (bool allowed);
+
+  /**
+   * @notice Whether an address is a member of a fund
+   * @param id The ID of the fund
+   * @param member The address
+   * @return status Whether the address is a member
+   */
+  function isMember(uint256 id, address member) external view returns (bool status);
+
+  /**
+   * @notice A member's share balance in a fund
+   * @param id The ID of the fund
+   * @param member The member
+   * @return shares The member's shares
+   */
+  function sharesOf(uint256 id, address member) external view returns (uint256 shares);
+
+  /**
+   * @notice A member's index in the fund's append-only member list
+   * @param id The ID of the fund
+   * @param member The member
+   * @return index The member's index (fund owner is index 0)
+   */
+  function memberIndex(uint256 id, address member) external view returns (uint256 index);
+
+  /**
+   * @notice Whether a voter has voted on a proposal
+   * @param id The ID of the fund
+   * @param proposalId The proposal ID
+   * @param voter The voter
+   * @return voted Whether the voter has voted
+   */
+  function hasVoted(uint256 id, uint256 proposalId, address voter) external view returns (bool voted);
+
+  /**
+   * @notice Whether an invite nonce has been consumed for a fund
+   * @param id The ID of the fund
+   * @param nonce The invite nonce
+   * @return used Whether the nonce has been used
+   */
+  function usedNonces(uint256 id, uint256 nonce) external view returns (bool used);
+}

--- a/src/interfaces/IGoalSavingCircles.sol
+++ b/src/interfaces/IGoalSavingCircles.sol
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+/**
+ * @title IGoalSavingCircles
+ * @notice Interface for goal-based group savings: members deposit flexible amounts toward a
+ *         target `goalAmount` before `deadline`. Funds are locked while funding (the commitment
+ *         device). On success the pot is released to a beneficiary, or — when no beneficiary is
+ *         set — each member reclaims exactly their own contributions. On failure or cancellation
+ *         every member is refunded exactly what they deposited.
+ * @dev No credit, no interest, no division: the contract only ever adds and subtracts exact
+ *      deposit amounts, so conservation of value is an equality, not a bound. Membership uses
+ *      the same EIP-712 'StacksInvite' domain as {ISavingCircles}.
+ */
+interface IGoalSavingCircles {
+  /**
+   * @notice Lifecycle state of a goal (derived, see goalState()).
+   * @dev Funding = 0 accepting deposits, goal not yet reached, deadline not passed.
+   *      Funded = 1 goal reached (latched); pot releasable (beneficiary set) or member
+   *                contributions unlocked (no beneficiary). Deposits stay open until deadline.
+   *      Failed = 2 deadline passed with the goal never reached; members withdraw refunds.
+   *      Cancelled = 3 owner cancelled during Funding; members withdraw refunds. Terminal.
+   *      Released = 4 pot paid out to the beneficiary. Terminal.
+   */
+  enum GoalState {
+    Funding,
+    Funded,
+    Failed,
+    Cancelled,
+    Released
+  }
+
+  /**
+   * @notice Immutable configuration of a goal, fixed at create().
+   * @param owner The goal organizer: signs invites, may cancel during Funding.
+   * @param token The allowlisted ERC20 all deposits and payouts use.
+   * @param beneficiary Recipient of the whole pot on success; address(0) means no beneficiary —
+   *        on success members individually reclaim their own contributions instead.
+   * @param goalAmount The funding target in token units (> 0). Deposits may overshoot it.
+   * @param deadline Unix timestamp; deposits are accepted strictly before it
+   *        (block.timestamp < deadline). At/after the deadline an unmet goal is Failed.
+   */
+  struct Goal {
+    address owner;
+    address token;
+    address beneficiary;
+    uint256 goalAmount;
+    uint256 deadline;
+  }
+
+  // =======================
+  // EVENTS
+  // =======================
+
+  /**
+   * @notice Emitted when a token is allowed or disallowed by the admin.
+   * @param token The token address.
+   * @param allowed Whether the token is now allowed.
+   */
+  event TokenAllowed(address indexed token, bool indexed allowed);
+
+  /**
+   * @notice Emitted when a goal is created.
+   * @param id The id of the new goal.
+   * @param owner The goal owner (the creator).
+   * @param token The ERC20 token used by the goal.
+   * @param goalAmount The funding target.
+   * @param deadline The funding deadline timestamp.
+   * @param beneficiary The pot recipient on success, or address(0) for commitment-savings mode.
+   */
+  event GoalCreated(
+    uint256 indexed id, address indexed owner, address token, uint256 goalAmount, uint256 deadline, address beneficiary
+  );
+
+  /**
+   * @notice Emitted when an invite is successfully redeemed and the redeemer becomes a member.
+   * @param id The id of the goal.
+   * @param redeemer The new member.
+   */
+  event InviteRedeemed(uint256 indexed id, address indexed redeemer);
+
+  /**
+   * @notice Emitted when a member's contribution is credited (deposit or depositFor).
+   * @param id The id of the goal.
+   * @param member The member credited with the contribution.
+   * @param amount The amount deposited.
+   */
+  event FundsDeposited(uint256 indexed id, address indexed member, uint256 amount);
+
+  /**
+   * @notice Emitted once, the first time totalDeposited reaches goalAmount.
+   * @param id The id of the goal.
+   * @param totalDeposited The pot size at the moment the goal was reached.
+   */
+  event GoalReached(uint256 indexed id, uint256 totalDeposited);
+
+  /**
+   * @notice Emitted when a member reclaims their contribution (success without beneficiary,
+   *         failure, or cancellation).
+   * @param id The id of the goal.
+   * @param member The member refunded.
+   * @param amount The amount refunded (the member's whole contribution).
+   */
+  event FundsWithdrawn(uint256 indexed id, address indexed member, uint256 amount);
+
+  /**
+   * @notice Emitted when the pot is released to the beneficiary.
+   * @param id The id of the goal.
+   * @param beneficiary The recipient of the pot.
+   * @param amount The whole pot paid out (goal target plus any overshoot).
+   */
+  event GoalReleased(uint256 indexed id, address indexed beneficiary, uint256 amount);
+
+  /**
+   * @notice Emitted when the owner cancels a goal during Funding.
+   * @param id The id of the goal.
+   */
+  event GoalCancelled(uint256 indexed id);
+
+  // =======================
+  // ERRORS
+  // =======================
+
+  /// @notice Thrown when creating a goal with a token that is not allowlisted.
+  error TokenNotAllowed();
+
+  /// @notice Thrown when creating a goal with goalAmount == 0.
+  error InvalidGoalAmount();
+
+  /// @notice Thrown when creating a goal with deadline <= block.timestamp.
+  error InvalidDeadline();
+
+  /// @notice Thrown when the goal id does not exist.
+  error GoalNotFound();
+
+  /// @notice Thrown when a goal is not accepting deposits or new members
+  ///         (cancelled, released, or block.timestamp >= deadline).
+  error GoalNotOpen();
+
+  /// @notice Thrown when the account is not a member of the goal.
+  error NotMember();
+
+  /// @notice Thrown when the caller is already a member of the goal.
+  error AlreadyMember();
+
+  /// @notice Thrown when an invite nonce has already been used for this goal.
+  error InviteAlreadyUsed();
+
+  /// @notice Thrown when the invite signature does not recover to the goal owner.
+  error InvalidSigner();
+
+  /// @notice Thrown when depositing zero tokens.
+  error InvalidDeposit();
+
+  /// @notice Thrown when the caller is not the goal owner.
+  error NotOwner();
+
+  /// @notice Thrown when cancel() is called in any state other than Funding.
+  error NotCancellable();
+
+  /// @notice Thrown when release() preconditions fail: goal not Funded, no beneficiary set,
+  ///         or already released.
+  error NotReleasable();
+
+  /// @notice Thrown when withdraw() is called while contributions are still locked
+  ///         (Funding, or Funded with a beneficiary set, or Released).
+  error NotWithdrawable();
+
+  /// @notice Thrown when the caller has no contribution to withdraw.
+  error NothingToWithdraw();
+
+  // =======================
+  // FUNCTIONS
+  // =======================
+
+  /**
+   * @notice Initialize the contract.
+   * @param owner The admin (token allowlist manager).
+   */
+  function initialize(address owner) external;
+
+  /**
+   * @notice Allow or disallow an ERC20 token for new goals. Admin only.
+   * @dev Allowlist changes never affect existing goals, which store their token. The admin must
+   *      not allowlist fee-on-transfer or rebasing tokens: exact-amount accounting assumes
+   *      standard ERC20 transfer semantics.
+   * @param token The token address.
+   * @param allowed Whether the token is allowed.
+   */
+  function setTokenAllowed(address token, bool allowed) external;
+
+  /**
+   * @notice Create a goal. The caller becomes the goal owner and its first member.
+   * @param token Allowlisted ERC20 used for the goal.
+   * @param goalAmount Funding target, must be > 0. Overshooting deposits are allowed.
+   * @param deadline Unix timestamp, must be > block.timestamp. Deposits close at the deadline.
+   * @param beneficiary Pot recipient on success, or address(0) for commitment-savings mode
+   *        (members reclaim their own contributions on success).
+   * @return id The id of the new goal.
+   */
+  function create(
+    address token,
+    uint256 goalAmount,
+    uint256 deadline,
+    address beneficiary
+  ) external returns (uint256 id);
+
+  /**
+   * @notice Join a goal with an EIP-712 invite signed by the goal owner.
+   * @dev Same 'StacksInvite' domain and Invite(uint256 id,uint256 nonce) typehash as
+   *      SavingCircles. Redeemable whenever the goal is open (Funding, or Funded before the
+   *      deadline), so latecomers can still help overshoot.
+   * @param id The id of the goal.
+   * @param nonce Unique invite nonce.
+   * @param signature The goal owner's EIP-712 signature over (id, nonce).
+   */
+  function redeemInvite(uint256 id, uint256 nonce, bytes calldata signature) external;
+
+  /**
+   * @notice Deposit tokens toward the goal. Any amount, any number of times, while the goal is
+   *         open. Overshooting goalAmount is allowed.
+   * @param id The id of the goal.
+   * @param value The amount to deposit (> 0).
+   */
+  function deposit(uint256 id, uint256 value) external;
+
+  /**
+   * @notice Deposit on behalf of a member: tokens are pulled from the caller, the contribution
+   *         (and any later refund right) is credited to `member`.
+   * @param id The id of the goal.
+   * @param member The member to credit; must already be a member.
+   * @param value The amount to deposit (> 0).
+   */
+  function depositFor(uint256 id, address member, uint256 value) external;
+
+  /**
+   * @notice Withdraw the caller's entire contribution. Available when the goal is Failed,
+   *         Cancelled, or Funded with no beneficiary. Full-balance only.
+   * @param id The id of the goal.
+   */
+  function withdraw(uint256 id) external;
+
+  /**
+   * @notice Release the whole pot (including overshoot) to the beneficiary. Permissionless once
+   *         the goal is Funded and a beneficiary is set; no time limit.
+   * @param id The id of the goal.
+   */
+  function release(uint256 id) external;
+
+  /**
+   * @notice Cancel a goal during Funding. Goal owner only. Unlocks full refunds for everyone.
+   * @param id The id of the goal.
+   */
+  function cancel(uint256 id) external;
+
+  // =======================
+  // VIEWS
+  // =======================
+
+  /**
+   * @notice Get a goal's configuration.
+   * @param id The id of the goal.
+   * @return goal The goal config. Reverts with GoalNotFound for unknown ids.
+   */
+  function getGoal(uint256 id) external view returns (Goal memory goal);
+
+  /**
+   * @notice Get the derived lifecycle state of a goal (precedence:
+   *         Cancelled > Released > Funded > Failed > Funding).
+   * @param id The id of the goal.
+   * @return state The goal state. Reverts with GoalNotFound for unknown ids.
+   */
+  function goalState(uint256 id) external view returns (GoalState state);
+
+  /**
+   * @notice Get the members of a goal (owner first, then invite-redemption order).
+   * @param id The id of the goal.
+   * @return members The member addresses.
+   */
+  function getGoalMembers(uint256 id) external view returns (address[] memory members);
+
+  /**
+   * @notice Get all goal ids an address is a member of.
+   * @param member The member address.
+   * @return ids The goal ids.
+   */
+  function getMemberGoals(address member) external view returns (uint256[] memory ids);
+
+  /**
+   * @notice Get members and their current locked contributions, aligned by index.
+   * @param id The id of the goal.
+   * @return members The member addresses.
+   * @return amounts Each member's current contribution.
+   */
+  function getMemberContributions(uint256 id) external view returns (address[] memory members, uint256[] memory amounts);
+
+  /**
+   * @notice Check if a token is allowed.
+   * @param token The token address.
+   * @return allowed Whether the token is allowed.
+   */
+  function isTokenAllowed(address token) external view returns (bool allowed);
+
+  /**
+   * @notice Next id that will be assigned to a new goal.
+   * @return nextId The next goal id.
+   */
+  function nextId() external view returns (uint256 nextId);
+
+  /**
+   * @notice Current escrowed pot of a goal.
+   * @param id The id of the goal.
+   * @return amount The live escrow: sum of inflows minus sum of outflows for the goal.
+   */
+  function totalDeposited(uint256 id) external view returns (uint256 amount);
+
+  /**
+   * @notice Current locked contribution of a member in a goal.
+   * @param id The id of the goal.
+   * @param member The member address.
+   * @return amount The member's current contribution.
+   */
+  function contributions(uint256 id, address member) external view returns (uint256 amount);
+
+  /**
+   * @notice Whether an address is a member of a goal.
+   * @param id The id of the goal.
+   * @param member The address to check.
+   * @return status Whether the address is a member.
+   */
+  function isMember(uint256 id, address member) external view returns (bool status);
+
+  /**
+   * @notice Whether the goal ever reached goalAmount (one-way latch).
+   * @param id The id of the goal.
+   * @return reached Whether the goal was ever reached.
+   */
+  function goalReached(uint256 id) external view returns (bool reached);
+
+  /**
+   * @notice Whether the goal was cancelled by its owner.
+   * @param id The id of the goal.
+   * @return status Whether the goal was cancelled.
+   */
+  function cancelled(uint256 id) external view returns (bool status);
+
+  /**
+   * @notice Whether the pot was released to the beneficiary.
+   * @param id The id of the goal.
+   * @return status Whether the pot was released.
+   */
+  function released(uint256 id) external view returns (bool status);
+
+  /**
+   * @notice Whether an invite nonce has been used for a goal.
+   * @param id The id of the goal.
+   * @param nonce The invite nonce.
+   * @return used Whether the nonce has been used.
+   */
+  function usedNonces(uint256 id, uint256 nonce) external view returns (bool used);
+}

--- a/test/unit/AccumulatingSavingCirclesUnit.t.sol
+++ b/test/unit/AccumulatingSavingCirclesUnit.t.sol
@@ -1,0 +1,1211 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {Initializable} from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {StdStorage, Test, stdStorage} from 'forge-std/Test.sol';
+
+import {AccumulatingSavingCircles} from 'src/contracts/AccumulatingSavingCircles.sol';
+import {IAccumulatingSavingCircles} from 'src/interfaces/IAccumulatingSavingCircles.sol';
+import {MockERC20} from 'test/mocks/MockERC20.sol';
+
+/**
+ * @notice Unit tests for {AccumulatingSavingCircles}.
+ * @dev Base fixture: alice organizes fund 0 (100% credit line, 5%/period simple interest, due
+ *      after 4 periods of 1 week) and invites bob and carol. All actors hold START_BAL tokens and
+ *      have approved the contract.
+ *
+ *      Reachability note: the internal ledger provably keeps `poolCash >= ` every member
+ *      entitlement in all reachable states (spec invariants I2/I3), so the defensive
+ *      InsufficientLiquidity guards cannot be triggered through the public API alone. Tests that
+ *      exercise those branches lower `poolCash` directly via stdstore to simulate a hypothetical
+ *      accounting shortfall.
+ */
+contract AccumulatingSavingCirclesUnit is Test {
+  using stdStorage for StdStorage;
+
+  AccumulatingSavingCircles public asca;
+  MockERC20 public token;
+
+  address public owner;
+  address public alice;
+  address public bob;
+  address public carol;
+  address public dave;
+  address public stranger;
+
+  uint256 internal _ownerKey;
+  uint256 internal _aliceKey;
+  uint256 internal _bobKey;
+  uint256 internal _carolKey;
+
+  uint256 public constant BORROW_LIMIT_BPS = 10_000;
+  uint256 public constant INTEREST_RATE_BPS = 500;
+  uint256 public constant REPAYMENT_PERIODS = 4;
+  uint256 public constant PERIOD_LENGTH = 1 weeks;
+  uint256 public constant DEPOSIT = 100 ether;
+  uint256 public constant START_BAL = 1_000_000 ether;
+  /// @dev All tests start (and all loans open) at this timestamp. Warps use absolute times
+  ///      anchored here because via-ir CSE can cache `block.timestamp` reads within a test.
+  uint256 public constant START_TIME = 365 days;
+
+  uint256 public fundId;
+
+  function setUp() public {
+    (owner, _ownerKey) = makeAddrAndKey('owner');
+    (alice, _aliceKey) = makeAddrAndKey('alice');
+    (bob, _bobKey) = makeAddrAndKey('bob');
+    (carol, _carolKey) = makeAddrAndKey('carol');
+    dave = makeAddr('dave');
+    stranger = makeAddr('stranger');
+
+    vm.warp(START_TIME);
+
+    vm.startPrank(owner);
+    asca = AccumulatingSavingCircles(
+      address(
+        new TransparentUpgradeableProxy(
+          address(new AccumulatingSavingCircles()),
+          address(new ProxyAdmin(owner)),
+          abi.encodeWithSelector(AccumulatingSavingCircles.initialize.selector, owner)
+        )
+      )
+    );
+    token = new MockERC20('Test', 'TST');
+    asca.setTokenAllowed(address(token), true);
+    vm.stopPrank();
+
+    address[4] memory _actors = [alice, bob, carol, dave];
+    for (uint256 _i = 0; _i < _actors.length; _i++) {
+      token.mint(_actors[_i], START_BAL);
+      vm.prank(_actors[_i]);
+      token.approve(address(asca), type(uint256).max);
+    }
+
+    vm.prank(alice);
+    fundId = asca.create(address(token), BORROW_LIMIT_BPS, INTEREST_RATE_BPS, REPAYMENT_PERIODS, PERIOD_LENGTH);
+    _join(bob, 1);
+    _join(carol, 2);
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  /// @dev Builds an EIP-712 StacksInvite signature for this contract as verifying contract.
+  function _signInvite(uint256 _id, uint256 _nonce, uint256 _signerKey) internal view returns (bytes memory) {
+    bytes32 _inviteTypehash = keccak256('Invite(uint256 id,uint256 nonce)');
+    bytes32 _structHash = keccak256(abi.encode(_inviteTypehash, _id, _nonce));
+    bytes32 _domainSeparator = keccak256(
+      abi.encode(
+        keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
+        keccak256(bytes('StacksInvite')),
+        keccak256(bytes('1')),
+        block.chainid,
+        address(asca)
+      )
+    );
+    bytes32 _digest = keccak256(abi.encodePacked('\x19\x01', _domainSeparator, _structHash));
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_signerKey, _digest);
+    return abi.encodePacked(_r, _s, _v);
+  }
+
+  function _join(address _who, uint256 _nonce) internal {
+    bytes memory _signature = _signInvite(fundId, _nonce, _aliceKey);
+    vm.prank(_who);
+    asca.redeemInvite(fundId, _nonce, _signature);
+  }
+
+  function _depositAs(address _who, uint256 _amount) internal {
+    vm.prank(_who);
+    asca.deposit(fundId, _amount);
+  }
+
+  function _borrowAs(address _who, uint256 _amount) internal {
+    vm.prank(_who);
+    asca.borrow(fundId, _amount);
+  }
+
+  function _repayAs(address _who, uint256 _amount) internal {
+    vm.prank(_who);
+    asca.repay(fundId, _amount);
+  }
+
+  /// @dev alice saves `_depositAmount` and borrows `_borrowAmount`; returns the loan's due date.
+  function _setupLoan(uint256 _depositAmount, uint256 _borrowAmount) internal returns (uint256 _dueDate) {
+    _depositAs(alice, _depositAmount);
+    _borrowAs(alice, _borrowAmount);
+    _dueDate = block.timestamp + REPAYMENT_PERIODS * PERIOD_LENGTH;
+  }
+
+  /// @dev alice and bob save 100 each; alice borrows 100 and fully repays 105 after one period,
+  ///      distributing 5 ether of interest over 200 shares => 2.5 ether pending each.
+  function _setupDistribution() internal {
+    _depositAs(alice, DEPOSIT);
+    _depositAs(bob, DEPOSIT);
+    _borrowAs(alice, DEPOSIT);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+    _repayAs(alice, 105 ether);
+  }
+
+  /// @dev Forces the fund's internal cash ledger to `_value` to reach the defensive liquidity guards.
+  function _forcePoolCash(uint256 _id, uint256 _value) internal {
+    stdstore.target(address(asca)).sig(asca.poolCash.selector).with_key(_id).checked_write(_value);
+  }
+
+  // ==========================================================================
+  // Initialization & admin
+  // ==========================================================================
+
+  function test_InitializeSetsOwner() public {
+    assertEq(asca.owner(), owner);
+
+    // A fresh proxy deployment initializes with the given owner.
+    AccumulatingSavingCircles _fresh = AccumulatingSavingCircles(
+      address(
+        new TransparentUpgradeableProxy(
+          address(new AccumulatingSavingCircles()),
+          address(new ProxyAdmin(owner)),
+          abi.encodeWithSelector(AccumulatingSavingCircles.initialize.selector, alice)
+        )
+      )
+    );
+    assertEq(_fresh.owner(), alice);
+  }
+
+  function test_InitializeRevertsWhenCalledTwice() public {
+    vm.expectRevert(Initializable.InvalidInitialization.selector);
+    asca.initialize(alice);
+  }
+
+  function test_SetTokenAllowedWhenCallerIsOwner() public {
+    address _newToken = makeAddr('newToken');
+
+    vm.prank(owner);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.TokenAllowed(_newToken, true);
+    asca.setTokenAllowed(_newToken, true);
+
+    assertTrue(asca.allowedTokens(_newToken));
+    assertTrue(asca.isTokenAllowed(_newToken));
+
+    vm.prank(owner);
+    asca.setTokenAllowed(_newToken, false);
+    assertFalse(asca.isTokenAllowed(_newToken));
+  }
+
+  function test_SetTokenAllowedWhenCallerIsNotOwner() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, alice));
+    asca.setTokenAllowed(makeAddr('newToken'), true);
+  }
+
+  // ==========================================================================
+  // Create
+  // ==========================================================================
+
+  function test_CreateFundWithValidParameters() public {
+    vm.prank(bob);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.FundCreated(1, bob, address(token), 5000, 300, REPAYMENT_PERIODS, PERIOD_LENGTH);
+    uint256 _id = asca.create(address(token), 5000, 300, REPAYMENT_PERIODS, PERIOD_LENGTH);
+
+    assertEq(_id, 1);
+    IAccumulatingSavingCircles.Fund memory _fund = asca.getFund(_id);
+    assertEq(_fund.owner, bob);
+    assertEq(_fund.token, address(token));
+    assertEq(_fund.borrowLimitBps, 5000);
+    assertEq(_fund.interestRateBps, 300);
+    assertEq(_fund.repaymentPeriods, REPAYMENT_PERIODS);
+    assertEq(_fund.periodLength, PERIOD_LENGTH);
+    assertFalse(_fund.deactivated);
+
+    assertTrue(asca.isMember(_id, bob));
+    address[] memory _fundMembers = asca.getFundMembers(_id);
+    assertEq(_fundMembers.length, 1);
+    assertEq(_fundMembers[0], bob);
+    uint256[] memory _bobFunds = asca.getMemberFunds(bob);
+    assertEq(_bobFunds.length, 2);
+    assertEq(_bobFunds[0], fundId);
+    assertEq(_bobFunds[1], _id);
+  }
+
+  function test_CreateFundIncrementsNextId() public {
+    assertEq(asca.nextId(), 1);
+    vm.prank(bob);
+    asca.create(address(token), BORROW_LIMIT_BPS, INTEREST_RATE_BPS, REPAYMENT_PERIODS, PERIOD_LENGTH);
+    assertEq(asca.nextId(), 2);
+  }
+
+  function test_CreateFundWhenTokenNotAllowed() public {
+    MockERC20 _other = new MockERC20('Other', 'OTH');
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.TokenNotAllowed.selector));
+    asca.create(address(_other), BORROW_LIMIT_BPS, INTEREST_RATE_BPS, REPAYMENT_PERIODS, PERIOD_LENGTH);
+  }
+
+  function test_CreateFundWhenBorrowLimitExceedsMax() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InvalidParameters.selector));
+    asca.create(address(token), 10_001, INTEREST_RATE_BPS, REPAYMENT_PERIODS, PERIOD_LENGTH);
+  }
+
+  function test_CreateFundWhenInterestRateExceedsMax() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InvalidParameters.selector));
+    asca.create(address(token), BORROW_LIMIT_BPS, 10_001, REPAYMENT_PERIODS, PERIOD_LENGTH);
+  }
+
+  function test_CreateFundWhenRepaymentPeriodsZero() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InvalidParameters.selector));
+    asca.create(address(token), BORROW_LIMIT_BPS, INTEREST_RATE_BPS, 0, PERIOD_LENGTH);
+  }
+
+  function test_CreateFundWhenRepaymentPeriodsExceedsMax() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InvalidParameters.selector));
+    asca.create(address(token), BORROW_LIMIT_BPS, INTEREST_RATE_BPS, 1001, PERIOD_LENGTH);
+  }
+
+  function test_CreateFundWhenPeriodLengthZero() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InvalidParameters.selector));
+    asca.create(address(token), BORROW_LIMIT_BPS, INTEREST_RATE_BPS, REPAYMENT_PERIODS, 0);
+  }
+
+  function test_CreateFundWhenPeriodLengthExceedsMax() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InvalidParameters.selector));
+    asca.create(address(token), BORROW_LIMIT_BPS, INTEREST_RATE_BPS, REPAYMENT_PERIODS, 365 days + 1);
+  }
+
+  function test_CreateFundWithZeroBorrowLimitAllowed() public {
+    vm.prank(alice);
+    uint256 _id = asca.create(address(token), 0, INTEREST_RATE_BPS, REPAYMENT_PERIODS, PERIOD_LENGTH);
+    assertEq(asca.getFund(_id).borrowLimitBps, 0);
+
+    // A savings-only fund: every borrow reverts.
+    vm.startPrank(alice);
+    asca.deposit(_id, DEPOSIT);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.ExceedsCreditLine.selector));
+    asca.borrow(_id, 1);
+    vm.stopPrank();
+  }
+
+  // ==========================================================================
+  // Invites
+  // ==========================================================================
+
+  function test_RedeemInviteWithValidSignature() public {
+    bytes memory _signature = _signInvite(fundId, 7, _aliceKey);
+
+    vm.prank(dave);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.InviteRedeemed(fundId, dave);
+    asca.redeemInvite(fundId, 7, _signature);
+
+    assertTrue(asca.isMember(fundId, dave));
+    assertTrue(asca.usedNonces(fundId, 7));
+    address[] memory _fundMembers = asca.getFundMembers(fundId);
+    assertEq(_fundMembers.length, 4);
+    assertEq(_fundMembers[3], dave);
+    uint256[] memory _daveFunds = asca.getMemberFunds(dave);
+    assertEq(_daveFunds.length, 1);
+    assertEq(_daveFunds[0], fundId);
+  }
+
+  function test_RedeemInviteWhenSignerIsNotFundOwner() public {
+    bytes memory _signature = _signInvite(fundId, 7, _bobKey);
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InvalidSigner.selector));
+    asca.redeemInvite(fundId, 7, _signature);
+  }
+
+  function test_RedeemInviteWhenNonceAlreadyUsed() public {
+    _join(dave, 7);
+    bytes memory _signature = _signInvite(fundId, 7, _aliceKey);
+    vm.prank(stranger);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InviteAlreadyUsed.selector));
+    asca.redeemInvite(fundId, 7, _signature);
+  }
+
+  function test_RedeemInviteWhenAlreadyMember() public {
+    bytes memory _signature = _signInvite(fundId, 7, _aliceKey);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.AlreadyMember.selector));
+    asca.redeemInvite(fundId, 7, _signature);
+  }
+
+  function test_RedeemInviteWhenFundNotFound() public {
+    bytes memory _signature = _signInvite(99, 7, _aliceKey);
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotFound.selector));
+    asca.redeemInvite(99, 7, _signature);
+  }
+
+  function test_RedeemInviteWhenFundDeactivated() public {
+    vm.prank(alice);
+    asca.deactivate(fundId);
+
+    bytes memory _signature = _signInvite(fundId, 7, _aliceKey);
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotActive.selector));
+    asca.redeemInvite(fundId, 7, _signature);
+  }
+
+  // ==========================================================================
+  // Deposit
+  // ==========================================================================
+
+  function test_DepositIncreasesSavingsTotalsAndPoolCash() public {
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.SavingsDeposited(fundId, alice, DEPOSIT);
+    asca.deposit(fundId, DEPOSIT);
+
+    assertEq(asca.savings(fundId, alice), DEPOSIT);
+    assertEq(asca.totalSavings(fundId), DEPOSIT);
+    assertEq(asca.poolCash(fundId), DEPOSIT);
+    assertEq(token.balanceOf(address(asca)), DEPOSIT);
+    assertEq(token.balanceOf(alice), START_BAL - DEPOSIT);
+
+    (uint256 _totalSavings, uint256 _totalBorrowed, uint256 _poolCash) = asca.getFundBalances(fundId);
+    assertEq(_totalSavings, DEPOSIT);
+    assertEq(_totalBorrowed, 0);
+    assertEq(_poolCash, DEPOSIT);
+  }
+
+  function test_DepositWhenAmountIsZero() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.ZeroAmount.selector));
+    asca.deposit(fundId, 0);
+  }
+
+  function test_DepositWhenCallerIsNotMember() public {
+    vm.prank(stranger);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NotMember.selector));
+    asca.deposit(fundId, DEPOSIT);
+  }
+
+  function test_DepositWhenFundNotFound() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotFound.selector));
+    asca.deposit(99, DEPOSIT);
+  }
+
+  function test_DepositWhenFundDeactivated() public {
+    vm.prank(alice);
+    asca.deactivate(fundId);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotActive.selector));
+    asca.deposit(fundId, DEPOSIT);
+  }
+
+  function test_DepositSettlesPendingInterestBeforeBalanceChange() public {
+    // alice is the sole saver, borrows against herself and pays 5 ether of interest.
+    _depositAs(alice, DEPOSIT);
+    _borrowAs(alice, DEPOSIT);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+    _repayAs(alice, 105 ether);
+    assertEq(asca.pendingInterestOf(fundId, alice), 5 ether);
+
+    // Depositing more settles the pending amount and re-checkpoints without inflating it.
+    _depositAs(alice, 50 ether);
+    assertEq(asca.interestCredit(fundId, alice), 5 ether);
+    assertEq(asca.pendingInterestOf(fundId, alice), 5 ether);
+  }
+
+  function test_DepositForCreditsMemberAndPullsFromCaller() public {
+    vm.prank(bob);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.SavingsDeposited(fundId, carol, 40 ether);
+    asca.depositFor(fundId, carol, 40 ether);
+
+    assertEq(asca.savings(fundId, carol), 40 ether);
+    assertEq(asca.savings(fundId, bob), 0);
+    assertEq(token.balanceOf(bob), START_BAL - 40 ether);
+    assertEq(token.balanceOf(carol), START_BAL);
+  }
+
+  function test_DepositForWhenTargetIsNotMember() public {
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NotMember.selector));
+    asca.depositFor(fundId, stranger, 40 ether);
+  }
+
+  // ==========================================================================
+  // Withdraw
+  // ==========================================================================
+
+  function test_WithdrawFullSavingsWhenNoDebt() public {
+    _depositAs(alice, DEPOSIT);
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.SavingsWithdrawn(fundId, alice, DEPOSIT);
+    asca.withdraw(fundId, DEPOSIT);
+
+    assertEq(asca.savings(fundId, alice), 0);
+    assertEq(asca.totalSavings(fundId), 0);
+    assertEq(asca.poolCash(fundId), 0);
+    assertEq(token.balanceOf(alice), START_BAL);
+  }
+
+  function test_WithdrawWhenAmountIsZero() public {
+    _depositAs(alice, DEPOSIT);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.ZeroAmount.selector));
+    asca.withdraw(fundId, 0);
+  }
+
+  function test_WithdrawWhenCallerIsNotMember() public {
+    vm.prank(stranger);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NotMember.selector));
+    asca.withdraw(fundId, 1);
+  }
+
+  function test_WithdrawWhenAmountExceedsSavings() public {
+    _depositAs(alice, DEPOSIT);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InsufficientSavings.selector));
+    asca.withdraw(fundId, DEPOSIT + 1);
+  }
+
+  function test_WithdrawWhenPoolCashInsufficient() public {
+    _depositAs(alice, DEPOSIT);
+    _forcePoolCash(fundId, DEPOSIT - 1);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InsufficientLiquidity.selector));
+    asca.withdraw(fundId, DEPOSIT);
+  }
+
+  function test_WithdrawWhenRemainingSavingsWouldNotCollateralizeDebt() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InsufficientCollateral.selector));
+    asca.withdraw(fundId, 1);
+  }
+
+  function test_WithdrawGuardCountsAccruedInterestAsDebt() public {
+    _setupLoan(110 ether, DEPOSIT);
+
+    // Pre-accrual: debt is 100, remaining savings after a 5 withdraw is 105 >= 100.
+    vm.prank(alice);
+    asca.withdraw(fundId, 5 ether);
+
+    // After one period the debt is 105; the same withdraw would leave 100 < 105.
+    vm.warp(START_TIME + PERIOD_LENGTH);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InsufficientCollateral.selector));
+    asca.withdraw(fundId, 5 ether);
+  }
+
+  function test_WithdrawSettlesPendingInterest() public {
+    _setupDistribution();
+
+    vm.prank(bob);
+    asca.withdraw(fundId, 50 ether);
+
+    assertEq(asca.interestCredit(fundId, bob), 2.5 ether);
+    assertEq(asca.pendingInterestOf(fundId, bob), 2.5 ether);
+  }
+
+  function test_WithdrawAllowedWhenFundDeactivated() public {
+    _depositAs(alice, DEPOSIT);
+    vm.prank(alice);
+    asca.deactivate(fundId);
+
+    vm.prank(alice);
+    asca.withdraw(fundId, DEPOSIT);
+    assertEq(token.balanceOf(alice), START_BAL);
+  }
+
+  // ==========================================================================
+  // Borrow
+  // ==========================================================================
+
+  function test_BorrowTransfersCashAndOpensLoan() public {
+    _depositAs(alice, DEPOSIT);
+    uint256 _dueDate = block.timestamp + REPAYMENT_PERIODS * PERIOD_LENGTH;
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.Borrowed(fundId, alice, 60 ether, _dueDate);
+    asca.borrow(fundId, 60 ether);
+
+    (IAccumulatingSavingCircles.Loan memory _loan, uint256 _returnedDueDate) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, 60 ether);
+    assertEq(_loan.interestOwed, 0);
+    assertEq(_loan.periodsAccrued, 0);
+    assertEq(_loan.startTime, block.timestamp);
+    assertEq(_returnedDueDate, _dueDate);
+
+    assertEq(asca.totalBorrowed(fundId), 60 ether);
+    assertEq(asca.poolCash(fundId), 40 ether);
+    assertEq(token.balanceOf(alice), START_BAL - DEPOSIT + 60 ether);
+  }
+
+  function test_BorrowWhenAmountIsZero() public {
+    _depositAs(alice, DEPOSIT);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.ZeroAmount.selector));
+    asca.borrow(fundId, 0);
+  }
+
+  function test_BorrowWhenCallerIsNotMember() public {
+    vm.prank(stranger);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NotMember.selector));
+    asca.borrow(fundId, 1 ether);
+  }
+
+  function test_BorrowWhenFundDeactivated() public {
+    _depositAs(alice, DEPOSIT);
+    vm.prank(alice);
+    asca.deactivate(fundId);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotActive.selector));
+    asca.borrow(fundId, 1 ether);
+  }
+
+  function test_BorrowWhenLoanOutstanding() public {
+    _setupLoan(DEPOSIT, 10 ether);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.OutstandingLoan.selector));
+    asca.borrow(fundId, 10 ether);
+  }
+
+  function test_BorrowWhenAmountExceedsCreditLine() public {
+    _depositAs(alice, DEPOSIT);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.ExceedsCreditLine.selector));
+    asca.borrow(fundId, DEPOSIT + 1);
+  }
+
+  function test_BorrowWhenPoolCashInsufficient() public {
+    _depositAs(alice, DEPOSIT);
+    _forcePoolCash(fundId, 10 ether);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InsufficientLiquidity.selector));
+    asca.borrow(fundId, 50 ether);
+  }
+
+  function test_BorrowFullCreditLineAtMaxBps() public {
+    _depositAs(alice, DEPOSIT);
+    vm.prank(alice);
+    asca.borrow(fundId, DEPOSIT);
+
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, DEPOSIT);
+  }
+
+  function test_BorrowCreditLineRoundsDown() public {
+    vm.prank(alice);
+    uint256 _id = asca.create(address(token), 5000, INTEREST_RATE_BPS, REPAYMENT_PERIODS, PERIOD_LENGTH);
+
+    vm.startPrank(alice);
+    asca.deposit(_id, 101); // credit line = 101 * 5000 / 10_000 = 50 (floored from 50.5)
+    assertEq(asca.creditLineOf(_id, alice), 50);
+
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.ExceedsCreditLine.selector));
+    asca.borrow(_id, 51);
+
+    asca.borrow(_id, 50);
+    vm.stopPrank();
+
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(_id, alice);
+    assertEq(_loan.principal, 50);
+  }
+
+  function test_BorrowAgainAfterFullRepay() public {
+    _setupLoan(DEPOSIT, 50 ether);
+    _repayAs(alice, 50 ether); // same period => zero interest
+
+    vm.prank(alice);
+    asca.borrow(fundId, 60 ether);
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, 60 ether);
+  }
+
+  // ==========================================================================
+  // Interest accrual
+  // ==========================================================================
+
+  function test_InterestIsZeroBeforeFirstFullPeriod() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + PERIOD_LENGTH - 1);
+
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.interestOwed, 0);
+
+    // Repaying within the first period pays zero interest.
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.Repaid(fundId, alice, 0, DEPOSIT);
+    asca.repay(fundId, DEPOSIT);
+  }
+
+  function test_InterestAccruesPerWholeElapsedPeriod() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + 3 * PERIOD_LENGTH);
+
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.interestOwed, DEPOSIT * INTEREST_RATE_BPS * 3 / 10_000); // 15 ether
+    assertEq(_loan.periodsAccrued, 3);
+  }
+
+  function test_InterestAccrualCapsAtRepaymentPeriods() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + 10 * PERIOD_LENGTH);
+
+    uint256 _cappedInterest = DEPOSIT * INTEREST_RATE_BPS * REPAYMENT_PERIODS / 10_000; // 20 ether
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.interestOwed, _cappedInterest);
+    assertEq(_loan.periodsAccrued, REPAYMENT_PERIODS);
+
+    // The storage accrual path is capped too: a full repay pulls exactly principal + capped interest.
+    uint256 _balanceBefore = token.balanceOf(alice);
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.Repaid(fundId, alice, _cappedInterest, DEPOSIT);
+    asca.repay(fundId, 200 ether);
+    assertEq(_balanceBefore - token.balanceOf(alice), DEPOSIT + _cappedInterest);
+  }
+
+  function test_InterestAccruesOnReducedPrincipalAfterPartialRepay() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+    _repayAs(alice, 55 ether); // 5 interest + 50 principal, checkpointed at period 1
+
+    vm.warp(START_TIME + 2 * PERIOD_LENGTH); // period 2
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, 50 ether);
+    assertEq(_loan.interestOwed, 50 ether * INTEREST_RATE_BPS / 10_000); // 2.5 ether on the reduced principal
+  }
+
+  // ==========================================================================
+  // Repay
+  // ==========================================================================
+
+  function test_RepayWhenAmountIsZero() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.ZeroAmount.selector));
+    asca.repay(fundId, 0);
+  }
+
+  function test_RepayWhenNoActiveLoan() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NoActiveLoan.selector));
+    asca.repay(fundId, 1 ether);
+  }
+
+  function test_RepayAppliesInterestBeforePrincipal() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + PERIOD_LENGTH); // 5 ether of interest owed
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.Repaid(fundId, alice, 5 ether, 25 ether);
+    asca.repay(fundId, 30 ether);
+
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, 75 ether);
+    assertEq(_loan.interestOwed, 0);
+  }
+
+  function test_RepayPartialInterestOnlyLeavesPrincipalUntouched() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.Repaid(fundId, alice, 3 ether, 0);
+    asca.repay(fundId, 3 ether);
+
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, DEPOSIT);
+    assertEq(_loan.interestOwed, 2 ether);
+    assertEq(asca.totalBorrowed(fundId), DEPOSIT);
+  }
+
+  function test_RepayFullClosesLoan() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+    _repayAs(alice, 105 ether);
+
+    (IAccumulatingSavingCircles.Loan memory _loan, uint256 _dueDate) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, 0);
+    assertEq(_loan.interestOwed, 0);
+    assertEq(_loan.startTime, 0);
+    assertEq(_dueDate, 0);
+    assertEq(asca.totalBorrowed(fundId), 0);
+    assertEq(asca.poolCash(fundId), 105 ether);
+  }
+
+  function test_RepayOverpaymentPullsOnlyTotalDebt() public {
+    _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+
+    uint256 _balanceBefore = token.balanceOf(alice);
+    _repayAs(alice, 1000 ether);
+    assertEq(_balanceBefore - token.balanceOf(alice), 105 ether);
+  }
+
+  function test_RepayDistributesInterestToSaversProRata() public {
+    _depositAs(alice, 100 ether);
+    _depositAs(bob, 300 ether);
+    _borrowAs(alice, 100 ether);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.InterestDistributed(fundId, 5 ether);
+    asca.repay(fundId, 105 ether);
+
+    // acc = 5e18 * 1e18 / 400e18; alice holds 1/4 of the shares, bob 3/4.
+    assertEq(asca.pendingInterestOf(fundId, alice), 1.25 ether);
+    assertEq(asca.pendingInterestOf(fundId, bob), 3.75 ether);
+  }
+
+  // ==========================================================================
+  // Accumulator & claims
+  // ==========================================================================
+
+  function test_PendingInterestProRataBySavings() public {
+    _setupDistribution();
+    assertEq(asca.pendingInterestOf(fundId, alice), 2.5 ether);
+    assertEq(asca.pendingInterestOf(fundId, bob), 2.5 ether);
+    assertEq(asca.pendingInterestOf(fundId, carol), 0);
+  }
+
+  function test_DepositAfterDistributionEarnsNoPastInterest() public {
+    _setupDistribution();
+
+    _depositAs(carol, DEPOSIT);
+    assertEq(asca.pendingInterestOf(fundId, carol), 0);
+
+    // carol does share in the next distribution (5 ether over 300 shares).
+    _borrowAs(alice, DEPOSIT);
+    vm.warp(START_TIME + 2 * PERIOD_LENGTH);
+    _repayAs(alice, 105 ether);
+    uint256 _acc = uint256(5 ether) * 1e18 / 300 ether;
+    assertEq(asca.pendingInterestOf(fundId, carol), DEPOSIT * _acc / 1e18);
+  }
+
+  function test_BorrowerSavingsKeepEarningWhileBorrowed() public {
+    _depositAs(alice, 100 ether);
+    _depositAs(bob, 300 ether);
+    _borrowAs(alice, 100 ether);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+    _repayAs(alice, 105 ether);
+
+    // alice's savings stayed shares while borrowed: she earns 1/4 of her own interest payment.
+    assertEq(asca.pendingInterestOf(fundId, alice), 1.25 ether);
+  }
+
+  function test_InterestDistributionRoundsDownAndDustStaysInPool() public {
+    _depositAs(alice, 1 ether);
+    _depositAs(bob, 2 ether);
+    _borrowAs(alice, 1 ether);
+    vm.warp(START_TIME + PERIOD_LENGTH);
+    _repayAs(alice, 2 ether); // pulls 1.05 ether; distributes 0.05 ether over 3 ether of shares
+
+    uint256 _alicePending = asca.pendingInterestOf(fundId, alice);
+    uint256 _bobPending = asca.pendingInterestOf(fundId, bob);
+    assertLe(_alicePending + _bobPending, 0.05 ether);
+    assertEq(0.05 ether - (_alicePending + _bobPending), 2); // 2 wei of dust
+
+    vm.prank(alice);
+    asca.claimInterest(fundId);
+    vm.prank(bob);
+    asca.claimInterest(fundId);
+
+    // The dust stays in poolCash as an untracked surplus; the contract can back all claims.
+    assertEq(asca.poolCash(fundId), asca.totalSavings(fundId) + 2);
+    assertEq(token.balanceOf(address(asca)), asca.poolCash(fundId));
+  }
+
+  function test_ClaimInterestTransfersAndResetsCredit() public {
+    _setupDistribution();
+    uint256 _poolCashBefore = asca.poolCash(fundId);
+
+    vm.prank(bob);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.InterestClaimed(fundId, bob, 2.5 ether);
+    asca.claimInterest(fundId);
+
+    assertEq(asca.poolCash(fundId), _poolCashBefore - 2.5 ether);
+    assertEq(asca.pendingInterestOf(fundId, bob), 0);
+    assertEq(token.balanceOf(bob), START_BAL - DEPOSIT + 2.5 ether);
+
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NothingToClaim.selector));
+    asca.claimInterest(fundId);
+  }
+
+  function test_ClaimInterestWhenNothingToClaim() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NothingToClaim.selector));
+    asca.claimInterest(fundId);
+  }
+
+  function test_ClaimInterestWhenPoolCashInsufficient() public {
+    _setupDistribution();
+    _forcePoolCash(fundId, 1);
+
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.InsufficientLiquidity.selector));
+    asca.claimInterest(fundId);
+  }
+
+  // ==========================================================================
+  // Liquidate
+  // ==========================================================================
+
+  function test_LiquidateWhenLoanNotOverdue() public {
+    uint256 _dueDate = _setupLoan(DEPOSIT, DEPOSIT);
+
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NotLiquidatable.selector));
+    asca.liquidate(fundId, alice);
+
+    vm.warp(_dueDate - 1);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NotLiquidatable.selector));
+    asca.liquidate(fundId, alice);
+  }
+
+  function test_LiquidateWhenNoActiveLoan() public {
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NoActiveLoan.selector));
+    asca.liquidate(fundId, bob);
+  }
+
+  function test_LiquidateAtDueDateSeizesPrincipalAndInterest() public {
+    _depositAs(bob, 100 ether);
+    uint256 _dueDate = _setupLoan(150 ether, 100 ether);
+    vm.warp(_dueDate); // 20 ether of interest owed, frozen at the cap
+
+    uint256 _contractBalanceBefore = token.balanceOf(address(asca));
+    uint256 _poolCashBefore = asca.poolCash(fundId);
+
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.InterestDistributed(fundId, 20 ether);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.Liquidated(fundId, alice, 100 ether, 20 ether);
+    asca.liquidate(fundId, alice);
+
+    // Pure ledger reallocation: no tokens moved, poolCash untouched.
+    assertEq(token.balanceOf(address(asca)), _contractBalanceBefore);
+    assertEq(asca.poolCash(fundId), _poolCashBefore);
+
+    assertEq(asca.savings(fundId, alice), 30 ether);
+    assertEq(asca.totalSavings(fundId), 130 ether);
+    assertEq(asca.totalBorrowed(fundId), 0);
+
+    (IAccumulatingSavingCircles.Loan memory _loan, uint256 _returnedDueDate) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, 0);
+    assertEq(_returnedDueDate, 0);
+    assertFalse(asca.isLiquidatable(fundId, alice));
+  }
+
+  function test_LiquidateIsPermissionless() public {
+    uint256 _dueDate = _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(_dueDate);
+
+    vm.prank(stranger);
+    asca.liquidate(fundId, alice);
+    assertEq(asca.totalBorrowed(fundId), 0);
+  }
+
+  function test_LiquidateWithInterestShortfallSeizesOnlyAvailableSavings() public {
+    _depositAs(bob, 100 ether);
+    uint256 _dueDate = _setupLoan(105 ether, 100 ether);
+    vm.warp(_dueDate); // interest owed is 20 ether but only 5 ether of savings remain above principal
+
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.Liquidated(fundId, alice, 100 ether, 5 ether);
+    asca.liquidate(fundId, alice);
+
+    assertEq(asca.savings(fundId, alice), 0);
+    assertEq(asca.totalSavings(fundId), 100 ether);
+  }
+
+  function test_LiquidateSoleSaverSkipsInterestSeizure() public {
+    // alice is the only saver: seizing her interest would leave zero shares to distribute to.
+    uint256 _dueDate = _setupLoan(110 ether, 100 ether);
+    vm.warp(_dueDate);
+
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.Liquidated(fundId, alice, 100 ether, 0);
+    asca.liquidate(fundId, alice);
+
+    assertEq(asca.savings(fundId, alice), 10 ether);
+    assertEq(asca.totalSavings(fundId), 10 ether);
+    assertEq(asca.accInterestPerShare(fundId), 0);
+  }
+
+  function test_LiquidateDistributesSeizedInterestToRemainingSavers() public {
+    _depositAs(bob, 100 ether);
+    uint256 _dueDate = _setupLoan(150 ether, 100 ether);
+    vm.warp(_dueDate);
+
+    asca.liquidate(fundId, alice);
+
+    // 20 ether distributed over the 130 ether of shares left after the seizure; alice's own
+    // remaining 30 ether of savings still count as shares.
+    uint256 _acc = uint256(20 ether) * 1e18 / 130 ether;
+    assertEq(asca.accInterestPerShare(fundId), _acc);
+    assertEq(asca.pendingInterestOf(fundId, bob), 100 ether * _acc / 1e18);
+    assertEq(asca.pendingInterestOf(fundId, alice), 30 ether * _acc / 1e18);
+  }
+
+  function test_LiquidateRestoresPoolLiquidityForWithdrawals() public {
+    // Liquidity crunch: alice borrows her whole savings, so poolCash exactly equals bob's claim.
+    _depositAs(bob, DEPOSIT);
+    uint256 _dueDate = _setupLoan(DEPOSIT, DEPOSIT);
+    assertEq(asca.poolCash(fundId), DEPOSIT);
+
+    // alice defaults; permissionless liquidation extinguishes the receivable at the due date.
+    vm.warp(_dueDate);
+    asca.liquidate(fundId, alice);
+    assertEq(asca.totalBorrowed(fundId), 0);
+
+    // bob can exit in full and the fund drains exactly.
+    vm.prank(bob);
+    asca.withdraw(fundId, DEPOSIT);
+    assertEq(token.balanceOf(bob), START_BAL);
+    assertEq(asca.poolCash(fundId), 0);
+    assertEq(asca.totalSavings(fundId), 0);
+  }
+
+  function test_LiquidateAllowedWhenFundDeactivated() public {
+    uint256 _dueDate = _setupLoan(DEPOSIT, DEPOSIT);
+    vm.prank(alice);
+    asca.deactivate(fundId);
+
+    vm.warp(_dueDate);
+    asca.liquidate(fundId, alice);
+    assertEq(asca.totalBorrowed(fundId), 0);
+  }
+
+  function test_BorrowAfterLiquidationWithFreshSavings() public {
+    uint256 _dueDate = _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(_dueDate);
+    asca.liquidate(fundId, alice);
+    assertEq(asca.savings(fundId, alice), 0);
+
+    _depositAs(alice, 50 ether);
+    vm.prank(alice);
+    asca.borrow(fundId, 25 ether);
+
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, 25 ether);
+  }
+
+  // ==========================================================================
+  // Deactivate
+  // ==========================================================================
+
+  function test_DeactivateWhenCallerIsNotFundOwner() public {
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.NotFundOwner.selector));
+    asca.deactivate(fundId);
+  }
+
+  function test_DeactivateWhenAlreadyDeactivated() public {
+    vm.startPrank(alice);
+    asca.deactivate(fundId);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotActive.selector));
+    asca.deactivate(fundId);
+    vm.stopPrank();
+  }
+
+  function test_DeactivateBlocksDepositBorrowAndInvitesButAllowsExits() public {
+    _depositAs(alice, DEPOSIT);
+    _borrowAs(alice, 50 ether);
+    vm.warp(START_TIME + PERIOD_LENGTH); // 2.5 ether of interest owed
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit IAccumulatingSavingCircles.FundDeactivated(fundId);
+    asca.deactivate(fundId);
+    assertTrue(asca.getFund(fundId).deactivated);
+
+    // Frozen: deposit / depositFor / borrow / redeemInvite.
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotActive.selector));
+    asca.deposit(fundId, 1 ether);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotActive.selector));
+    asca.depositFor(fundId, alice, 1 ether);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotActive.selector));
+    asca.borrow(fundId, 1 ether);
+    bytes memory _signature = _signInvite(fundId, 7, _aliceKey);
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotActive.selector));
+    asca.redeemInvite(fundId, 7, _signature);
+
+    // Open: repay, claimInterest, withdraw.
+    _repayAs(alice, 52.5 ether);
+    vm.startPrank(alice);
+    asca.claimInterest(fundId); // 2.5 ether, alice is the sole saver
+    asca.withdraw(fundId, DEPOSIT);
+    vm.stopPrank();
+
+    assertEq(asca.poolCash(fundId), 0);
+    assertEq(token.balanceOf(alice), START_BAL);
+  }
+
+  // ==========================================================================
+  // Views
+  // ==========================================================================
+
+  function test_GetFundWhenFundNotFound() public {
+    vm.expectRevert(abi.encodeWithSelector(IAccumulatingSavingCircles.FundNotFound.selector));
+    asca.getFund(99);
+  }
+
+  function test_GetLoanReflectsLiveAccrualAndDueDate() public {
+    uint256 _dueDate = _setupLoan(DEPOSIT, DEPOSIT);
+    vm.warp(START_TIME + 2 * PERIOD_LENGTH);
+
+    (IAccumulatingSavingCircles.Loan memory _loan, uint256 _returnedDueDate) = asca.getLoan(fundId, alice);
+    assertEq(_loan.principal, DEPOSIT);
+    assertEq(_loan.interestOwed, 10 ether); // 2 whole periods at 5%
+    assertEq(_loan.periodsAccrued, 2);
+    assertEq(_returnedDueDate, _dueDate);
+  }
+
+  function test_CreditLineOfFloors() public {
+    vm.prank(alice);
+    uint256 _id = asca.create(address(token), 2500, INTEREST_RATE_BPS, REPAYMENT_PERIODS, PERIOD_LENGTH);
+
+    vm.prank(alice);
+    asca.deposit(_id, 7);
+    assertEq(asca.creditLineOf(_id, alice), 1); // floor(7 * 2500 / 10_000) = floor(1.75)
+  }
+
+  function test_MaxBorrowableOfIsMinOfCreditLineAndPoolCashAndZeroWhenLoanOpenOrDeactivated() public {
+    _depositAs(alice, DEPOSIT);
+    assertEq(asca.maxBorrowableOf(fundId, alice), DEPOSIT); // creditLine == poolCash
+
+    // poolCash below the credit line bounds the result.
+    _forcePoolCash(fundId, 30 ether);
+    assertEq(asca.maxBorrowableOf(fundId, alice), 30 ether);
+    _forcePoolCash(fundId, DEPOSIT);
+
+    // Zero while a loan is open.
+    _borrowAs(alice, 40 ether);
+    assertEq(asca.maxBorrowableOf(fundId, alice), 0);
+    _repayAs(alice, 40 ether);
+    assertEq(asca.maxBorrowableOf(fundId, alice), DEPOSIT);
+
+    // Zero once deactivated.
+    vm.prank(alice);
+    asca.deactivate(fundId);
+    assertEq(asca.maxBorrowableOf(fundId, alice), 0);
+  }
+
+  function test_WithdrawableOfEqualsSavingsPlusPendingInterest() public {
+    _setupDistribution();
+    assertEq(asca.withdrawableOf(fundId, bob), DEPOSIT + 2.5 ether);
+    assertEq(asca.withdrawableOf(fundId, carol), 0);
+  }
+
+  function test_IsLiquidatableBranches() public {
+    assertFalse(asca.isLiquidatable(fundId, alice)); // no loan
+
+    uint256 _dueDate = _setupLoan(DEPOSIT, DEPOSIT);
+    assertFalse(asca.isLiquidatable(fundId, alice)); // not due yet
+
+    vm.warp(_dueDate);
+    assertTrue(asca.isLiquidatable(fundId, alice)); // due
+  }
+
+  function test_GetFundMembersAndGetMemberFunds() public {
+    address[] memory _fundMembers = asca.getFundMembers(fundId);
+    assertEq(_fundMembers.length, 3);
+    assertEq(_fundMembers[0], alice);
+    assertEq(_fundMembers[1], bob);
+    assertEq(_fundMembers[2], carol);
+
+    vm.prank(alice);
+    uint256 _id = asca.create(address(token), BORROW_LIMIT_BPS, INTEREST_RATE_BPS, REPAYMENT_PERIODS, PERIOD_LENGTH);
+    uint256[] memory _aliceFunds = asca.getMemberFunds(alice);
+    assertEq(_aliceFunds.length, 2);
+    assertEq(_aliceFunds[0], fundId);
+    assertEq(_aliceFunds[1], _id);
+  }
+
+  // ==========================================================================
+  // Conservation
+  // ==========================================================================
+
+  function test_ConservationAcrossFullLifecycle() public {
+    _depositAs(alice, 100 ether);
+    _depositAs(bob, 200 ether);
+    _borrowAs(alice, 100 ether);
+    vm.warp(START_TIME + 2 * PERIOD_LENGTH);
+    _repayAs(alice, 110 ether); // 10 ether of interest over 300 ether of shares
+
+    vm.prank(alice);
+    asca.claimInterest(fundId);
+    vm.prank(bob);
+    asca.claimInterest(fundId);
+    vm.prank(alice);
+    asca.withdraw(fundId, 100 ether);
+    vm.prank(bob);
+    asca.withdraw(fundId, 200 ether);
+
+    // Everyone exited: only floor-rounding dust remains, fully backed by tokens.
+    uint256 _acc = uint256(10 ether) * 1e18 / 300 ether;
+    uint256 _dust = 10 ether - (100 ether * _acc / 1e18 + 200 ether * _acc / 1e18);
+    assertEq(asca.totalSavings(fundId), 0);
+    assertEq(asca.totalBorrowed(fundId), 0);
+    assertEq(asca.poolCash(fundId), _dust);
+    assertEq(token.balanceOf(address(asca)), _dust);
+    assertEq(token.balanceOf(alice), START_BAL - 10 ether + 100 ether * _acc / 1e18);
+    assertEq(token.balanceOf(bob), START_BAL + 200 ether * _acc / 1e18);
+  }
+
+  // ==========================================================================
+  // Fuzz
+  // ==========================================================================
+
+  function testFuzz_InterestAccrualMatchesFormula(uint256 _principal, uint256 _elapsedPeriods) public {
+    _principal = bound(_principal, 1, 1_000_000 ether);
+    _elapsedPeriods = bound(_elapsedPeriods, 0, 3 * REPAYMENT_PERIODS);
+
+    token.mint(alice, _principal);
+    vm.startPrank(alice);
+    asca.deposit(fundId, _principal);
+    asca.borrow(fundId, _principal);
+    vm.stopPrank();
+
+    vm.warp(START_TIME + _elapsedPeriods * PERIOD_LENGTH);
+
+    uint256 _cappedPeriods = _elapsedPeriods < REPAYMENT_PERIODS ? _elapsedPeriods : REPAYMENT_PERIODS;
+    (IAccumulatingSavingCircles.Loan memory _loan,) = asca.getLoan(fundId, alice);
+    assertEq(_loan.interestOwed, _principal * INTEREST_RATE_BPS * _cappedPeriods / 10_000);
+    assertEq(_loan.periodsAccrued, _cappedPeriods);
+  }
+
+  function testFuzz_DepositWithdrawRoundTrip(uint256 _amount) public {
+    _amount = bound(_amount, 1, START_BAL);
+
+    vm.startPrank(alice);
+    asca.deposit(fundId, _amount);
+    asca.withdraw(fundId, _amount);
+    vm.stopPrank();
+
+    assertEq(token.balanceOf(alice), START_BAL);
+    assertEq(asca.savings(fundId, alice), 0);
+    assertEq(asca.totalSavings(fundId), 0);
+    assertEq(asca.poolCash(fundId), 0);
+  }
+}

--- a/test/unit/CollectiveFundCirclesUnit.t.sol
+++ b/test/unit/CollectiveFundCirclesUnit.t.sol
@@ -1,0 +1,1227 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {Initializable} from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {Test} from 'forge-std/Test.sol';
+
+import {CollectiveFundCircles} from 'src/contracts/CollectiveFundCircles.sol';
+import {ICollectiveFundCircles} from 'src/interfaces/ICollectiveFundCircles.sol';
+import {MockERC20} from 'test/mocks/MockERC20.sol';
+
+/**
+ * @notice Unit tests for {CollectiveFundCircles} — the Logos white-label communal fund.
+ * @dev Self-contained: deploys its own TransparentUpgradeableProxy in setUp. Fixture
+ *      `baseFundId` = fund(token, orga, 'Logos Quito', 7 days, 6_000 bps) with alice + bob
+ *      joined via EIP-712 invites, so electorate = 3 and requiredYes = ceil(1.8) = 2.
+ */
+contract CollectiveFundCirclesUnit is Test {
+  CollectiveFundCircles public collective;
+  MockERC20 public token;
+
+  address public owner; // contract admin (token allowlist)
+  address public orga; // fund organizer
+  address public alice;
+  address public bob;
+  address public carol;
+  address public dave; // never a baseFund member
+  address public recipient;
+
+  uint256 internal _orgaKey;
+  uint256 internal _aliceKey;
+
+  uint256 public constant VOTING_PERIOD = 7 days;
+  uint256 public constant THRESHOLD_BPS = 6000;
+  uint256 public constant START_BAL = 1000 ether;
+  uint256 public constant DEPOSIT = 100 ether;
+  string public constant FUND_NAME = 'Logos Quito';
+  string public constant DESCRIPTION = 'venue deposit';
+
+  uint256 public baseFundId;
+  uint256 internal _nextNonce;
+
+  function setUp() public {
+    (owner,) = makeAddrAndKey('owner');
+    (orga, _orgaKey) = makeAddrAndKey('orga');
+    (alice, _aliceKey) = makeAddrAndKey('alice');
+    (bob,) = makeAddrAndKey('bob');
+    (carol,) = makeAddrAndKey('carol');
+    (dave,) = makeAddrAndKey('dave');
+    (recipient,) = makeAddrAndKey('recipient');
+
+    vm.startPrank(owner);
+    collective = CollectiveFundCircles(
+      address(
+        new TransparentUpgradeableProxy(
+          address(new CollectiveFundCircles()),
+          address(new ProxyAdmin(owner)),
+          abi.encodeWithSelector(CollectiveFundCircles.initialize.selector, owner)
+        )
+      )
+    );
+    token = new MockERC20('Test', 'TST');
+    collective.setTokenAllowed(address(token), true);
+    vm.stopPrank();
+
+    address[5] memory actors = [orga, alice, bob, carol, dave];
+    for (uint256 i = 0; i < actors.length; i++) {
+      token.mint(actors[i], START_BAL);
+      vm.prank(actors[i]);
+      token.approve(address(collective), type(uint256).max);
+    }
+
+    baseFundId = collective.create(address(token), orga, FUND_NAME, VOTING_PERIOD, THRESHOLD_BPS);
+    _join(baseFundId, alice);
+    _join(baseFundId, bob);
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  /// @dev EIP-712 invite signature (domain 'StacksInvite' v1) with this contract as verifyingContract.
+  function _signInvite(
+    address _verifyingContract,
+    uint256 _fundId,
+    uint256 _nonce,
+    uint256 _signerKey
+  ) internal view returns (bytes memory) {
+    bytes32 inviteTypehash = keccak256('Invite(uint256 id,uint256 nonce)');
+    bytes32 structHash = keccak256(abi.encode(inviteTypehash, _fundId, _nonce));
+    bytes32 eip712DomainTypehash =
+      keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)');
+    bytes32 domainSeparator = keccak256(
+      abi.encode(eip712DomainTypehash, keccak256('StacksInvite'), keccak256('1'), block.chainid, _verifyingContract)
+    );
+    bytes32 digest = keccak256(abi.encodePacked('\x19\x01', domainSeparator, structHash));
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(_signerKey, digest);
+    return abi.encodePacked(r, s, v);
+  }
+
+  /// @dev Join `_member` to fund `_id` with an orga-signed invite and a fresh nonce.
+  function _join(uint256 _id, address _member) internal {
+    uint256 nonce = _nextNonce++;
+    bytes memory signature = _signInvite(address(collective), _id, nonce, _orgaKey);
+    vm.prank(_member);
+    collective.redeemInvite(_id, nonce, signature);
+  }
+
+  function _deposit(uint256 _id, address _member, uint256 _amount) internal {
+    vm.prank(_member);
+    collective.deposit(_id, _amount);
+  }
+
+  /// @dev Propose in baseFund as orga (auto-yes) and vote yes as alice -> requiredYes 2 reached.
+  function _passProposal(uint256 _amount) internal returns (uint256 proposalId) {
+    vm.prank(orga);
+    proposalId = collective.propose(baseFundId, recipient, _amount, DESCRIPTION);
+    vm.prank(alice);
+    collective.vote(baseFundId, proposalId, true);
+  }
+
+  /// @dev Fund the base pool, pass a proposal for `_amount` and execute it.
+  function _fundPassAndExecute(uint256 _depositAmount, uint256 _proposalAmount) internal returns (uint256 proposalId) {
+    _deposit(baseFundId, alice, _depositAmount);
+    proposalId = _passProposal(_proposalAmount);
+    collective.execute(baseFundId, proposalId);
+  }
+
+  // ==========================================================================
+  // initialize / admin
+  // ==========================================================================
+
+  function test_InitializeSetsOwner() public view {
+    assertEq(collective.owner(), owner);
+  }
+
+  function test_InitializeRevertsWhenCalledTwice() public {
+    vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+    collective.initialize(alice);
+  }
+
+  function test_InitializeFreshProxyAndImplementationLockdown() public {
+    // A fresh proxy initializes normally.
+    CollectiveFundCircles fresh = CollectiveFundCircles(
+      address(
+        new TransparentUpgradeableProxy(
+          address(new CollectiveFundCircles()),
+          address(new ProxyAdmin(owner)),
+          abi.encodeWithSelector(CollectiveFundCircles.initialize.selector, alice)
+        )
+      )
+    );
+    assertEq(fresh.owner(), alice);
+
+    // The bare implementation has initializers disabled by its constructor.
+    CollectiveFundCircles implementation = new CollectiveFundCircles();
+    vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+    implementation.initialize(alice);
+  }
+
+  function test_SetTokenAllowedWhenCallerIsOwner() public {
+    address newToken = makeAddr('newToken');
+    vm.prank(owner);
+    collective.setTokenAllowed(newToken, true);
+    assertTrue(collective.isTokenAllowed(newToken));
+
+    vm.prank(owner);
+    collective.setTokenAllowed(newToken, false);
+    assertFalse(collective.isTokenAllowed(newToken));
+  }
+
+  function test_SetTokenAllowedWhenCallerIsNotOwner() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, alice));
+    collective.setTokenAllowed(address(token), false);
+  }
+
+  function test_SetTokenAllowedEmitsEvent() public {
+    address newToken = makeAddr('anotherToken');
+    vm.prank(owner);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.TokenAllowed(newToken, true);
+    collective.setTokenAllowed(newToken, true);
+  }
+
+  // ==========================================================================
+  // create
+  // ==========================================================================
+
+  function test_CreateFundWithValidParameters() public {
+    uint256 expectedId = collective.nextId();
+
+    vm.prank(dave); // permissionless
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.FundCreated(expectedId, orga, address(token), 'Logos Cell', 3 days, 5000);
+    uint256 id = collective.create(address(token), orga, 'Logos Cell', 3 days, 5000);
+
+    assertEq(id, expectedId);
+
+    ICollectiveFundCircles.Fund memory fund = collective.getFund(id);
+    assertEq(fund.owner, orga);
+    assertEq(fund.token, address(token));
+    assertEq(fund.votingPeriod, 3 days);
+    assertEq(fund.approvalThresholdBps, 5000);
+    assertEq(fund.totalShares, 0);
+    assertEq(fund.poolBalance, 0);
+    assertEq(fund.proposalCount, 0);
+    assertEq(fund.name, 'Logos Cell');
+
+    // The fund owner auto-joins at index 0.
+    assertTrue(collective.isMember(id, orga));
+    assertEq(collective.memberIndex(id, orga), 0);
+    address[] memory members = collective.getFundMembers(id);
+    assertEq(members.length, 1);
+    assertEq(members[0], orga);
+
+    uint256[] memory orgaFunds = collective.getMemberFunds(orga);
+    assertEq(orgaFunds[orgaFunds.length - 1], id);
+  }
+
+  function test_CreateFundIncrementsNextId() public {
+    uint256 before = collective.nextId();
+    uint256 id = collective.create(address(token), orga, FUND_NAME, VOTING_PERIOD, THRESHOLD_BPS);
+    assertEq(id, before);
+    assertEq(collective.nextId(), before + 1);
+  }
+
+  function test_CreateFundRevertsWhenTokenNotAllowed() public {
+    MockERC20 other = new MockERC20('Other', 'OTH');
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.TokenNotAllowed.selector));
+    collective.create(address(other), orga, FUND_NAME, VOTING_PERIOD, THRESHOLD_BPS);
+  }
+
+  function test_CreateFundRevertsWhenOwnerIsZero() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidFundOwner.selector));
+    collective.create(address(token), address(0), FUND_NAME, VOTING_PERIOD, THRESHOLD_BPS);
+  }
+
+  function test_CreateFundRevertsWhenNameEmpty() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidName.selector));
+    collective.create(address(token), orga, '', VOTING_PERIOD, THRESHOLD_BPS);
+  }
+
+  function test_CreateFundRevertsWhenVotingPeriodZero() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidVotingPeriod.selector));
+    collective.create(address(token), orga, FUND_NAME, 0, THRESHOLD_BPS);
+  }
+
+  function test_CreateFundRevertsWhenVotingPeriodExceedsMax() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidVotingPeriod.selector));
+    collective.create(address(token), orga, FUND_NAME, 365 days + 1, THRESHOLD_BPS);
+  }
+
+  function test_CreateFundRevertsWhenThresholdZero() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidThreshold.selector));
+    collective.create(address(token), orga, FUND_NAME, VOTING_PERIOD, 0);
+  }
+
+  function test_CreateFundRevertsWhenThresholdAboveMaxBps() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidThreshold.selector));
+    collective.create(address(token), orga, FUND_NAME, VOTING_PERIOD, 10_001);
+  }
+
+  // ==========================================================================
+  // redeemInvite
+  // ==========================================================================
+
+  function test_RedeemInviteWithValidSignature() public {
+    uint256 nonce = 777;
+    bytes memory signature = _signInvite(address(collective), baseFundId, nonce, _orgaKey);
+
+    vm.prank(carol);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.InviteRedeemed(baseFundId, carol);
+    collective.redeemInvite(baseFundId, nonce, signature);
+
+    assertTrue(collective.isMember(baseFundId, carol));
+    assertEq(collective.memberIndex(baseFundId, carol), 3);
+    assertTrue(collective.usedNonces(baseFundId, nonce));
+
+    address[] memory members = collective.getFundMembers(baseFundId);
+    assertEq(members.length, 4);
+    assertEq(members[3], carol);
+
+    uint256[] memory carolFunds = collective.getMemberFunds(carol);
+    assertEq(carolFunds.length, 1);
+    assertEq(carolFunds[0], baseFundId);
+  }
+
+  function test_RedeemInviteRevertsWhenFundNotFound() public {
+    bytes memory signature = _signInvite(address(collective), 999, 0, _orgaKey);
+    vm.prank(carol);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.redeemInvite(999, 0, signature);
+  }
+
+  function test_RedeemInviteRevertsWhenNonceAlreadyUsed() public {
+    uint256 nonce = 42_000;
+    bytes memory signature = _signInvite(address(collective), baseFundId, nonce, _orgaKey);
+    vm.prank(carol);
+    collective.redeemInvite(baseFundId, nonce, signature);
+
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InviteAlreadyUsed.selector));
+    collective.redeemInvite(baseFundId, nonce, signature);
+  }
+
+  function test_RedeemInviteRevertsWhenAlreadyMember() public {
+    uint256 nonce = 43_000;
+    bytes memory signature = _signInvite(address(collective), baseFundId, nonce, _orgaKey);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.AlreadyMember.selector));
+    collective.redeemInvite(baseFundId, nonce, signature);
+  }
+
+  function test_RedeemInviteRevertsWhenSignerIsNotFundOwner() public {
+    uint256 nonce = 44_000;
+    bytes memory signature = _signInvite(address(collective), baseFundId, nonce, _aliceKey);
+    vm.prank(carol);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidSigner.selector));
+    collective.redeemInvite(baseFundId, nonce, signature);
+  }
+
+  function test_RedeemInviteSucceedsAfterProposalsExist() public {
+    vm.prank(orga);
+    collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    // Funds are perpetual: invites redeem at any time, even with proposals in flight.
+    _join(baseFundId, carol);
+    assertTrue(collective.isMember(baseFundId, carol));
+  }
+
+  // ==========================================================================
+  // deposit
+  // ==========================================================================
+
+  function test_DepositMintsSharesOneToOne() public {
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.FundsDeposited(baseFundId, alice, DEPOSIT);
+    collective.deposit(baseFundId, DEPOSIT);
+
+    assertEq(collective.sharesOf(baseFundId, alice), DEPOSIT);
+    ICollectiveFundCircles.Fund memory fund = collective.getFund(baseFundId);
+    assertEq(fund.totalShares, DEPOSIT);
+    assertEq(fund.poolBalance, DEPOSIT);
+    assertEq(token.balanceOf(address(collective)), DEPOSIT);
+    assertEq(token.balanceOf(alice), START_BAL - DEPOSIT);
+  }
+
+  function test_DepositRevertsWhenNotMember() public {
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.NotMember.selector));
+    collective.deposit(baseFundId, DEPOSIT);
+  }
+
+  function test_DepositRevertsWhenZeroAmount() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidAmount.selector));
+    collective.deposit(baseFundId, 0);
+  }
+
+  function test_DepositRevertsWhenFundNotFound() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.deposit(999, DEPOSIT);
+  }
+
+  function test_DepositAfterDisbursementStillMintsOneToOne() public {
+    // alice deposits 100, community spends 50 -> pool 50, shares 100.
+    _fundPassAndExecute(DEPOSIT, DEPOSIT / 2);
+
+    // bob's late deposit still mints 1:1 ...
+    _deposit(baseFundId, bob, DEPOSIT);
+    assertEq(collective.sharesOf(baseFundId, bob), DEPOSIT);
+
+    // ... so he immediately shares the past dilution equally per contributed token:
+    // previewWithdraw = 100 * 150 / 200 = 75 < 100.
+    assertEq(collective.previewWithdraw(baseFundId, bob), 75 ether);
+    assertLt(collective.previewWithdraw(baseFundId, bob), DEPOSIT);
+  }
+
+  // ==========================================================================
+  // donate
+  // ==========================================================================
+
+  function test_DonateIncreasesPoolWithoutMintingShares() public {
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.FundsDonated(baseFundId, alice, DEPOSIT);
+    collective.donate(baseFundId, DEPOSIT);
+
+    ICollectiveFundCircles.Fund memory fund = collective.getFund(baseFundId);
+    assertEq(fund.poolBalance, DEPOSIT);
+    assertEq(fund.totalShares, 0);
+    assertEq(collective.sharesOf(baseFundId, alice), 0);
+  }
+
+  function test_DonateByNonMember() public {
+    vm.prank(dave);
+    collective.donate(baseFundId, DEPOSIT);
+    assertEq(collective.getFund(baseFundId).poolBalance, DEPOSIT);
+    assertEq(token.balanceOf(dave), START_BAL - DEPOSIT);
+  }
+
+  function test_DonateRevertsWhenZeroAmount() public {
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidAmount.selector));
+    collective.donate(baseFundId, 0);
+  }
+
+  function test_DonateRevertsWhenFundNotFound() public {
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.donate(999, DEPOSIT);
+  }
+
+  function test_DonateWithZeroTotalSharesIsSpendableByProposal() public {
+    // No shares exist, only a donation.
+    vm.prank(dave);
+    collective.donate(baseFundId, DEPOSIT);
+
+    uint256 proposalId = _passProposal(60 ether);
+    collective.execute(baseFundId, proposalId);
+
+    assertEq(token.balanceOf(recipient), 60 ether);
+    assertEq(collective.getFund(baseFundId).poolBalance, 40 ether);
+  }
+
+  // ==========================================================================
+  // withdraw
+  // ==========================================================================
+
+  function test_WithdrawFullBalanceAtParityBeforeAnyDisbursement() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+
+    vm.prank(alice);
+    collective.withdraw(baseFundId, DEPOSIT);
+
+    assertEq(token.balanceOf(alice), START_BAL);
+    assertEq(collective.sharesOf(baseFundId, alice), 0);
+    ICollectiveFundCircles.Fund memory fund = collective.getFund(baseFundId);
+    assertEq(fund.totalShares, 0);
+    assertEq(fund.poolBalance, 0);
+  }
+
+  function test_WithdrawPartialShares() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+
+    vm.prank(alice);
+    collective.withdraw(baseFundId, 40 ether);
+
+    assertEq(token.balanceOf(alice), START_BAL - 60 ether);
+    assertEq(collective.sharesOf(baseFundId, alice), 60 ether);
+    assertEq(collective.getFund(baseFundId).poolBalance, 60 ether);
+    assertEq(collective.getFund(baseFundId).totalShares, 60 ether);
+  }
+
+  function test_WithdrawProRataAfterDisbursement() public {
+    // alice 100 + bob 100 -> pool 200; disburse 50 -> pool 150, shares 200.
+    _deposit(baseFundId, alice, DEPOSIT);
+    _deposit(baseFundId, bob, DEPOSIT);
+    uint256 proposalId = _passProposal(50 ether);
+    collective.execute(baseFundId, proposalId);
+
+    // alice burns all 100 shares: floor(100 * 150 / 200) = 75.
+    vm.prank(alice);
+    collective.withdraw(baseFundId, DEPOSIT);
+
+    assertEq(token.balanceOf(alice), START_BAL - DEPOSIT + 75 ether);
+    ICollectiveFundCircles.Fund memory fund = collective.getFund(baseFundId);
+    assertEq(fund.poolBalance, 75 ether);
+    assertEq(fund.totalShares, DEPOSIT);
+  }
+
+  function test_WithdrawRoundsDownAndLeavesDustInPool() public {
+    // Wei-level amounts: pool 199, shares 200; 3 shares -> floor(3 * 199 / 200) = 2 (not 2.985).
+    _deposit(baseFundId, alice, 100);
+    _deposit(baseFundId, bob, 100);
+    uint256 proposalId = _passProposal(1);
+    collective.execute(baseFundId, proposalId);
+
+    uint256 balanceBefore = token.balanceOf(alice);
+    vm.prank(alice);
+    collective.withdraw(baseFundId, 3);
+
+    assertEq(token.balanceOf(alice) - balanceBefore, 2);
+    // The 0.985 wei of dust stays in the pool for remaining shareholders.
+    assertEq(collective.getFund(baseFundId).poolBalance, 197);
+    assertEq(collective.getFund(baseFundId).totalShares, 197);
+  }
+
+  function test_WithdrawLastMemberSweepsExactPoolBalance() public {
+    // pool 167, shares 200 after a 33-wei disbursement.
+    _deposit(baseFundId, alice, 100);
+    _deposit(baseFundId, bob, 100);
+    uint256 proposalId = _passProposal(33);
+    collective.execute(baseFundId, proposalId);
+
+    vm.prank(alice);
+    collective.withdraw(baseFundId, 100); // floor(100 * 167 / 200) = 83 -> pool 84, shares 100
+
+    vm.prank(bob);
+    collective.withdraw(baseFundId, 100); // last out: 100 * 84 / 100 = 84 exactly
+
+    ICollectiveFundCircles.Fund memory fund = collective.getFund(baseFundId);
+    assertEq(fund.poolBalance, 0);
+    assertEq(fund.totalShares, 0);
+    assertEq(token.balanceOf(address(collective)), 0); // nothing stranded
+  }
+
+  function test_WithdrawZeroValueSharesWhenPoolEmpty() public {
+    // Fully spent fund: pool 0, shares 100.
+    _fundPassAndExecute(DEPOSIT, DEPOSIT);
+    assertEq(collective.getFund(baseFundId).poolBalance, 0);
+
+    // Share-base reset: burning worthless shares proceeds and pays 0.
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.FundsWithdrawn(baseFundId, alice, DEPOSIT, 0);
+    collective.withdraw(baseFundId, DEPOSIT);
+
+    assertEq(collective.sharesOf(baseFundId, alice), 0);
+    assertEq(collective.getFund(baseFundId).totalShares, 0);
+    assertEq(token.balanceOf(alice), START_BAL - DEPOSIT);
+  }
+
+  function test_WithdrawRevertsWhenZeroShares() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidAmount.selector));
+    collective.withdraw(baseFundId, 0);
+  }
+
+  function test_WithdrawRevertsWhenInsufficientShares() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InsufficientShares.selector));
+    collective.withdraw(baseFundId, DEPOSIT + 1);
+  }
+
+  function test_WithdrawRevertsWhenNotMember() public {
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.NotMember.selector));
+    collective.withdraw(baseFundId, 1);
+  }
+
+  function test_WithdrawRevertsWhenFundNotFound() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.withdraw(999, 1);
+  }
+
+  function test_WithdrawEmitsEvent() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.FundsWithdrawn(baseFundId, alice, 40 ether, 40 ether);
+    collective.withdraw(baseFundId, 40 ether);
+  }
+
+  function test_WithdrawNotBlockedByPassedProposal() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(DEPOSIT);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+
+    // Rage-quit is never blocked by a passed proposal.
+    vm.prank(alice);
+    collective.withdraw(baseFundId, DEPOSIT);
+    assertEq(token.balanceOf(alice), START_BAL);
+
+    // The proposal stays Passed but is no longer executable.
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+    assertFalse(collective.isExecutable(baseFundId, proposalId));
+  }
+
+  // ==========================================================================
+  // setFundName
+  // ==========================================================================
+
+  function test_SetFundNameByFundOwner() public {
+    vm.prank(orga);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.FundNameUpdated(baseFundId, 'Logos Uio');
+    collective.setFundName(baseFundId, 'Logos Uio');
+
+    assertEq(collective.getFund(baseFundId).name, 'Logos Uio');
+  }
+
+  function test_SetFundNameRevertsWhenNotFundOwner() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.NotFundOwner.selector));
+    collective.setFundName(baseFundId, 'Logos Uio');
+  }
+
+  function test_SetFundNameRevertsWhenEmpty() public {
+    vm.prank(orga);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidName.selector));
+    collective.setFundName(baseFundId, '');
+  }
+
+  function test_SetFundNameRevertsWhenFundNotFound() public {
+    vm.prank(orga);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.setFundName(999, 'Logos Uio');
+  }
+
+  // ==========================================================================
+  // propose
+  // ==========================================================================
+
+  function test_ProposeSnapshotsElectorateAndRequiredYes() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    ICollectiveFundCircles.Proposal memory proposal = collective.getProposal(baseFundId, proposalId);
+    assertEq(proposal.proposer, orga);
+    assertEq(proposal.recipient, recipient);
+    assertEq(proposal.amount, DEPOSIT);
+    assertEq(proposal.createdAt, block.timestamp);
+    assertEq(proposal.electorate, 3);
+    assertEq(proposal.requiredYes, 2); // ceil(3 * 6_000 / 10_000) = ceil(1.8) = 2
+    assertEq(proposal.noVotes, 0);
+    assertFalse(proposal.executed);
+    assertEq(proposal.description, DESCRIPTION);
+  }
+
+  function test_ProposeRequiredYesRoundsUp() public {
+    // 3 members @ 5_000 bps -> ceil(1.5) = 2 (true majority).
+    uint256 fund3 = collective.create(address(token), orga, FUND_NAME, VOTING_PERIOD, 5000);
+    _join(fund3, alice);
+    _join(fund3, bob);
+    vm.prank(orga);
+    uint256 p3 = collective.propose(fund3, recipient, 1, DESCRIPTION);
+    assertEq(collective.getProposal(fund3, p3).requiredYes, 2);
+
+    // 5 members @ 5_000 bps -> ceil(2.5) = 3 (true majority).
+    uint256 fund5 = collective.create(address(token), orga, FUND_NAME, VOTING_PERIOD, 5000);
+    _join(fund5, alice);
+    _join(fund5, bob);
+    _join(fund5, carol);
+    _join(fund5, dave);
+    vm.prank(orga);
+    uint256 p5 = collective.propose(fund5, recipient, 1, DESCRIPTION);
+    assertEq(collective.getProposal(fund5, p5).requiredYes, 3);
+
+    // 4 members @ 10_000 bps -> 4 (unanimity of the snapshot).
+    uint256 fund4 = collective.create(address(token), orga, FUND_NAME, VOTING_PERIOD, 10_000);
+    _join(fund4, alice);
+    _join(fund4, bob);
+    _join(fund4, carol);
+    vm.prank(orga);
+    uint256 p4 = collective.propose(fund4, recipient, 1, DESCRIPTION);
+    assertEq(collective.getProposal(fund4, p4).requiredYes, 4);
+  }
+
+  function test_ProposeAutoVotesYesForProposer() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    assertEq(collective.getProposal(baseFundId, proposalId).yesVotes, 1);
+    assertTrue(collective.hasVoted(baseFundId, proposalId, orga));
+  }
+
+  function test_ProposeSingleMemberFundPassesImmediately() public {
+    uint256 soloFund = collective.create(address(token), orga, 'Solo', VOTING_PERIOD, THRESHOLD_BPS);
+
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(soloFund, recipient, 1, DESCRIPTION);
+
+    ICollectiveFundCircles.Proposal memory proposal = collective.getProposal(soloFund, proposalId);
+    assertEq(proposal.requiredYes, 1);
+    assertTrue(collective.proposalState(soloFund, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+  }
+
+  function test_ProposeDoesNotReserveOrCheckPoolBalance() public {
+    // Pool is empty; a proposal for 1_000 ether is still accepted (checked at execute only).
+    assertEq(collective.getFund(baseFundId).poolBalance, 0);
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, 1000 ether, DESCRIPTION);
+    assertEq(collective.getProposal(baseFundId, proposalId).amount, 1000 ether);
+  }
+
+  function test_ProposeIncrementsProposalCount() public {
+    assertEq(collective.getFund(baseFundId).proposalCount, 0);
+
+    vm.prank(orga);
+    uint256 first = collective.propose(baseFundId, recipient, 1, DESCRIPTION);
+    vm.prank(alice);
+    uint256 second = collective.propose(baseFundId, recipient, 2, DESCRIPTION);
+
+    assertEq(first, 0);
+    assertEq(second, 1);
+    assertEq(collective.getFund(baseFundId).proposalCount, 2);
+  }
+
+  function test_ProposeRevertsWhenNotMember() public {
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.NotMember.selector));
+    collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+  }
+
+  function test_ProposeRevertsWhenRecipientIsZero() public {
+    vm.prank(orga);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidRecipient.selector));
+    collective.propose(baseFundId, address(0), DEPOSIT, DESCRIPTION);
+  }
+
+  function test_ProposeRevertsWhenRecipientIsContract() public {
+    vm.prank(orga);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidRecipient.selector));
+    collective.propose(baseFundId, address(collective), DEPOSIT, DESCRIPTION);
+  }
+
+  function test_ProposeRevertsWhenAmountZero() public {
+    vm.prank(orga);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InvalidAmount.selector));
+    collective.propose(baseFundId, recipient, 0, DESCRIPTION);
+  }
+
+  function test_ProposeRevertsWhenFundNotFound() public {
+    vm.prank(orga);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.propose(999, recipient, DEPOSIT, DESCRIPTION);
+  }
+
+  function test_ProposeEmitsEvent() public {
+    vm.prank(orga);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.ProposalCreated(baseFundId, 0, orga, recipient, DEPOSIT, DESCRIPTION);
+    collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+  }
+
+  // ==========================================================================
+  // vote
+  // ==========================================================================
+
+  function test_VoteYesIncrementsYesVotes() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.VoteCast(baseFundId, proposalId, alice, true);
+    collective.vote(baseFundId, proposalId, true);
+
+    ICollectiveFundCircles.Proposal memory proposal = collective.getProposal(baseFundId, proposalId);
+    assertEq(proposal.yesVotes, 2);
+    assertEq(proposal.noVotes, 0);
+    assertTrue(collective.hasVoted(baseFundId, proposalId, alice));
+  }
+
+  function test_VoteNoIncrementsNoVotes() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    vm.prank(alice);
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.VoteCast(baseFundId, proposalId, alice, false);
+    collective.vote(baseFundId, proposalId, false);
+
+    ICollectiveFundCircles.Proposal memory proposal = collective.getProposal(baseFundId, proposalId);
+    assertEq(proposal.yesVotes, 1);
+    assertEq(proposal.noVotes, 1);
+  }
+
+  function test_VoteReachingThresholdMakesProposalPassed() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Active);
+
+    vm.prank(alice);
+    collective.vote(baseFundId, proposalId, true); // yesVotes == requiredYes == 2
+
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+  }
+
+  function test_VoteRevertsWhenAlreadyVoted() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    // The proposer's auto-yes counts as their ballot.
+    vm.prank(orga);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.AlreadyVoted.selector));
+    collective.vote(baseFundId, proposalId, true);
+
+    vm.prank(alice);
+    collective.vote(baseFundId, proposalId, false);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.AlreadyVoted.selector));
+    collective.vote(baseFundId, proposalId, true);
+  }
+
+  function test_VoteRevertsWhenNotMember() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.NotMember.selector));
+    collective.vote(baseFundId, proposalId, true);
+  }
+
+  function test_VoteRevertsWhenMemberJoinedAfterSnapshot() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    _join(baseFundId, carol); // memberIndex 3 >= electorate 3
+
+    vm.prank(carol);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.NotEligible.selector));
+    collective.vote(baseFundId, proposalId, true);
+  }
+
+  function test_VoteAtVoteDeadlineBoundary() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+    uint256 createdAt = collective.getProposal(baseFundId, proposalId).createdAt;
+
+    vm.warp(createdAt + VOTING_PERIOD); // inclusive boundary
+    vm.prank(alice);
+    collective.vote(baseFundId, proposalId, true);
+    assertEq(collective.getProposal(baseFundId, proposalId).yesVotes, 2);
+  }
+
+  function test_VoteRevertsAfterVotingDeadline() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+    uint256 createdAt = collective.getProposal(baseFundId, proposalId).createdAt;
+
+    vm.warp(createdAt + VOTING_PERIOD + 1);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.VotingClosed.selector));
+    collective.vote(baseFundId, proposalId, true);
+  }
+
+  function test_VoteRevertsWhenProposalExecuted() public {
+    uint256 proposalId = _fundPassAndExecute(DEPOSIT, DEPOSIT / 2);
+
+    // Still inside the voting window, but the proposal has executed.
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.VotingClosed.selector));
+    collective.vote(baseFundId, proposalId, false);
+  }
+
+  function test_VoteRevertsWhenProposalNotFound() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.ProposalNotFound.selector));
+    collective.vote(baseFundId, 0, true);
+  }
+
+  function test_VoteRevertsWhenFundNotFound() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.vote(999, 0, true);
+  }
+
+  function test_VoteAllowedOnPassedProposalWithinWindow() public {
+    uint256 proposalId = _passProposal(DEPOSIT);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+
+    // Harmless signaling: bob may still vote no on a Passed proposal within the window.
+    vm.prank(bob);
+    collective.vote(baseFundId, proposalId, false);
+
+    assertEq(collective.getProposal(baseFundId, proposalId).noVotes, 1);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+  }
+
+  // ==========================================================================
+  // execute
+  // ==========================================================================
+
+  function test_ExecuteTransfersAmountAndMarksExecuted() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(60 ether);
+
+    vm.expectEmit(true, true, true, true);
+    emit ICollectiveFundCircles.ProposalExecuted(baseFundId, proposalId, recipient, 60 ether);
+    collective.execute(baseFundId, proposalId);
+
+    assertEq(token.balanceOf(recipient), 60 ether);
+    assertEq(collective.getFund(baseFundId).poolBalance, 40 ether);
+    assertTrue(collective.getProposal(baseFundId, proposalId).executed);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Executed);
+  }
+
+  function test_ExecuteEarlyOnceThresholdReachedBeforeVoteDeadline() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(DEPOSIT);
+
+    // No warp: we are well before the vote deadline, yet the proposal already executes.
+    uint256 createdAt = collective.getProposal(baseFundId, proposalId).createdAt;
+    assertLt(block.timestamp, createdAt + VOTING_PERIOD);
+
+    collective.execute(baseFundId, proposalId);
+    assertTrue(collective.getProposal(baseFundId, proposalId).executed);
+  }
+
+  function test_ExecuteByNonMemberIsPermissionless() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(DEPOSIT);
+
+    vm.prank(dave);
+    collective.execute(baseFundId, proposalId);
+    assertEq(token.balanceOf(recipient), DEPOSIT);
+  }
+
+  function test_ExecuteRevertsWhenThresholdNotReached() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION); // 1 yes < 2
+
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.ProposalNotPassed.selector));
+    collective.execute(baseFundId, proposalId);
+  }
+
+  function test_ExecuteRevertsWhenAlreadyExecuted() public {
+    uint256 proposalId = _fundPassAndExecute(DEPOSIT, DEPOSIT / 2);
+
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.ProposalAlreadyExecuted.selector));
+    collective.execute(baseFundId, proposalId);
+  }
+
+  function test_ExecuteRevertsAfterExecutionDeadline() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(DEPOSIT);
+    uint256 createdAt = collective.getProposal(baseFundId, proposalId).createdAt;
+
+    vm.warp(createdAt + 2 * VOTING_PERIOD + 1);
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.ProposalExpired.selector));
+    collective.execute(baseFundId, proposalId);
+  }
+
+  function test_ExecuteRevertsWhenPoolInsufficient() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(DEPOSIT);
+
+    // alice rage-quits between pass and execute, draining the pool.
+    vm.prank(alice);
+    collective.withdraw(baseFundId, DEPOSIT);
+
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.InsufficientPoolBalance.selector));
+    collective.execute(baseFundId, proposalId);
+  }
+
+  function test_ExecuteSucceedsAfterPoolRefilledWithinWindow() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(DEPOSIT);
+    vm.prank(alice);
+    collective.withdraw(baseFundId, DEPOSIT);
+
+    // Top-up re-enables the still-Passed proposal within its window.
+    _deposit(baseFundId, bob, DEPOSIT);
+    collective.execute(baseFundId, proposalId);
+
+    assertEq(token.balanceOf(recipient), DEPOSIT);
+    assertTrue(collective.getProposal(baseFundId, proposalId).executed);
+  }
+
+  function test_ExecuteRevertsWhenProposalNotFound() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.ProposalNotFound.selector));
+    collective.execute(baseFundId, 0);
+  }
+
+  function test_ExecuteRevertsWhenFundNotFound() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.execute(999, 0);
+  }
+
+  function test_ExecuteAtExecutionDeadlineBoundary() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(DEPOSIT);
+    uint256 createdAt = collective.getProposal(baseFundId, proposalId).createdAt;
+
+    vm.warp(createdAt + 2 * VOTING_PERIOD); // inclusive boundary
+    collective.execute(baseFundId, proposalId);
+    assertTrue(collective.getProposal(baseFundId, proposalId).executed);
+  }
+
+  // ==========================================================================
+  // proposalState / isExecutable / views
+  // ==========================================================================
+
+  function test_ProposalStateActiveWhileVotingOpen() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Active);
+  }
+
+  function test_ProposalStatePassedWithinExecutionWindow() public {
+    uint256 proposalId = _passProposal(DEPOSIT);
+    uint256 createdAt = collective.getProposal(baseFundId, proposalId).createdAt;
+
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+
+    // Still Passed after the vote deadline, while inside the execution window.
+    vm.warp(createdAt + VOTING_PERIOD + 1);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+  }
+
+  function test_ProposalStateExecuted() public {
+    uint256 proposalId = _fundPassAndExecute(DEPOSIT, DEPOSIT);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Executed);
+  }
+
+  function test_ProposalStateDefeatedAfterDeadlineWithoutThreshold() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+    uint256 createdAt = collective.getProposal(baseFundId, proposalId).createdAt;
+
+    vm.warp(createdAt + VOTING_PERIOD + 1);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Defeated);
+  }
+
+  function test_ProposalStateDefeatedEarlyWhenThresholdUnreachable() public {
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION);
+
+    // electorate 3, requiredYes 2, yes 1. After two no-votes: 3 - 2 = 1 < 2 -> unreachable.
+    vm.prank(alice);
+    collective.vote(baseFundId, proposalId, false);
+    vm.prank(bob);
+    collective.vote(baseFundId, proposalId, false);
+
+    // Defeated before the deadline.
+    assertLt(block.timestamp, collective.getProposal(baseFundId, proposalId).createdAt + VOTING_PERIOD);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Defeated);
+  }
+
+  function test_ProposalStateExpiredWhenPassedButUnexecuted() public {
+    uint256 proposalId = _passProposal(DEPOSIT);
+    uint256 createdAt = collective.getProposal(baseFundId, proposalId).createdAt;
+
+    vm.warp(createdAt + 2 * VOTING_PERIOD + 1);
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Expired);
+  }
+
+  function test_ProposalStateRevertsWhenProposalNotFound() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.ProposalNotFound.selector));
+    collective.proposalState(baseFundId, 0);
+  }
+
+  function test_IsExecutableFalseWhenPoolInsufficient() public {
+    uint256 proposalId = _passProposal(DEPOSIT); // pool is empty
+    assertTrue(collective.proposalState(baseFundId, proposalId) == ICollectiveFundCircles.ProposalState.Passed);
+    assertFalse(collective.isExecutable(baseFundId, proposalId));
+  }
+
+  function test_IsExecutableTrueWhenPassedAndFunded() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    uint256 proposalId = _passProposal(DEPOSIT);
+    assertTrue(collective.isExecutable(baseFundId, proposalId));
+  }
+
+  function test_IsExecutableFalseWhenNotPassedOrMissing() public {
+    _deposit(baseFundId, alice, DEPOSIT);
+    vm.prank(orga);
+    uint256 proposalId = collective.propose(baseFundId, recipient, DEPOSIT, DESCRIPTION); // Active
+
+    assertFalse(collective.isExecutable(baseFundId, proposalId)); // funded but not Passed
+    assertFalse(collective.isExecutable(baseFundId, 99)); // nonexistent proposal
+    assertFalse(collective.isExecutable(999, 0)); // nonexistent fund
+  }
+
+  function test_PreviewWithdrawReturnsZeroWhenTotalSharesZero() public {
+    assertEq(collective.previewWithdraw(baseFundId, alice), 0);
+
+    // Even with a donated pool, no shares means nothing is redeemable.
+    vm.prank(dave);
+    collective.donate(baseFundId, DEPOSIT);
+    assertEq(collective.previewWithdraw(baseFundId, alice), 0);
+  }
+
+  function test_PreviewWithdrawMatchesWithdrawPayout() public {
+    _deposit(baseFundId, alice, 100);
+    _deposit(baseFundId, bob, 100);
+    uint256 proposalId = _passProposal(33);
+    collective.execute(baseFundId, proposalId);
+
+    uint256 preview = collective.previewWithdraw(baseFundId, alice);
+    uint256 balanceBefore = token.balanceOf(alice);
+
+    vm.prank(alice);
+    collective.withdraw(baseFundId, 100);
+
+    assertEq(token.balanceOf(alice) - balanceBefore, preview);
+  }
+
+  function test_GetFundReturnsStoredFund() public view {
+    ICollectiveFundCircles.Fund memory fund = collective.getFund(baseFundId);
+    assertEq(fund.owner, orga);
+    assertEq(fund.token, address(token));
+    assertEq(fund.votingPeriod, VOTING_PERIOD);
+    assertEq(fund.approvalThresholdBps, THRESHOLD_BPS);
+    assertEq(fund.name, FUND_NAME);
+  }
+
+  function test_GetFundRevertsWhenNotFound() public {
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.FundNotFound.selector));
+    collective.getFund(999);
+  }
+
+  function test_GetFundsReturnsMultiple() public {
+    uint256 secondId = collective.create(address(token), orga, 'Second', 1 days, 1);
+
+    uint256[] memory ids = new uint256[](3);
+    ids[0] = baseFundId;
+    ids[1] = secondId;
+    ids[2] = 999; // nonexistent -> zeroed entry
+
+    ICollectiveFundCircles.Fund[] memory funds = collective.getFunds(ids);
+    assertEq(funds.length, 3);
+    assertEq(funds[0].name, FUND_NAME);
+    assertEq(funds[1].name, 'Second');
+    assertEq(funds[2].owner, address(0));
+  }
+
+  function test_GetFundMembersReturnsJoinOrder() public {
+    address[] memory members = collective.getFundMembers(baseFundId);
+    assertEq(members.length, 3);
+    assertEq(members[0], orga);
+    assertEq(members[1], alice);
+    assertEq(members[2], bob);
+
+    _join(baseFundId, carol);
+    members = collective.getFundMembers(baseFundId);
+    assertEq(members.length, 4);
+    assertEq(members[3], carol);
+  }
+
+  function test_GetMemberFundsAndCheckMemberships() public {
+    uint256 secondId = collective.create(address(token), orga, 'Second', 1 days, 1);
+    _join(secondId, alice);
+
+    uint256[] memory aliceFunds = collective.getMemberFunds(alice);
+    assertEq(aliceFunds.length, 2);
+    assertEq(aliceFunds[0], baseFundId);
+    assertEq(aliceFunds[1], secondId);
+
+    uint256[] memory ids = new uint256[](3);
+    ids[0] = baseFundId;
+    ids[1] = secondId;
+    ids[2] = 999;
+
+    bool[] memory aliceMemberships = collective.checkMemberships(alice, ids);
+    assertTrue(aliceMemberships[0]);
+    assertTrue(aliceMemberships[1]);
+    assertFalse(aliceMemberships[2]);
+
+    bool[] memory bobMemberships = collective.checkMemberships(bob, ids);
+    assertTrue(bobMemberships[0]);
+    assertFalse(bobMemberships[1]);
+  }
+
+  function test_GetProposalAndGetProposals() public {
+    vm.prank(orga);
+    collective.propose(baseFundId, recipient, 1 ether, 'first');
+    vm.prank(alice);
+    collective.propose(baseFundId, recipient, 2 ether, 'second');
+
+    ICollectiveFundCircles.Proposal[] memory proposals = collective.getProposals(baseFundId);
+    assertEq(proposals.length, 2);
+    assertEq(proposals[0].amount, 1 ether);
+    assertEq(proposals[0].proposer, orga);
+    assertEq(proposals[1].amount, 2 ether);
+    assertEq(proposals[1].proposer, alice);
+    assertEq(proposals[1].description, 'second');
+
+    ICollectiveFundCircles.Proposal memory single = collective.getProposal(baseFundId, 1);
+    assertEq(single.amount, proposals[1].amount);
+    assertEq(single.proposer, proposals[1].proposer);
+
+    vm.expectRevert(abi.encodeWithSelector(ICollectiveFundCircles.ProposalNotFound.selector));
+    collective.getProposal(baseFundId, 2);
+  }
+
+  // ==========================================================================
+  // cross-cutting conservation (I1 / I2 / I3)
+  // ==========================================================================
+
+  function test_ConservationAcrossDepositDonateWithdrawExecute() public {
+    // Second fund sharing the same token; alice belongs to both.
+    uint256 fundB = collective.create(address(token), orga, 'Fund B', 3 days, 5000);
+    _join(fundB, alice);
+
+    // Fund A activity: 100 + 50 deposits, 25 donation, disburse 60, alice burns 30 shares.
+    _deposit(baseFundId, alice, 100);
+    _deposit(baseFundId, bob, 50);
+    vm.prank(dave);
+    collective.donate(baseFundId, 25); // pool A = 175, shares A = 150
+
+    uint256 proposalId = _passProposal(60);
+    collective.execute(baseFundId, proposalId); // pool A = 115
+
+    vm.prank(alice);
+    collective.withdraw(baseFundId, 30); // floor(30 * 115 / 150) = 23 -> pool A = 92
+
+    // Fund B activity: 80 + 20 deposits, alice burns 20 shares at parity.
+    _deposit(fundB, orga, 80);
+    _deposit(fundB, alice, 20); // pool B = 100, shares B = 100
+    vm.prank(alice);
+    collective.withdraw(fundB, 20); // 20 * 100 / 100 = 20 -> pool B = 80
+
+    ICollectiveFundCircles.Fund memory fundA_ = collective.getFund(baseFundId);
+    ICollectiveFundCircles.Fund memory fundB_ = collective.getFund(fundB);
+
+    // I1 — share conservation per fund.
+    uint256 sharesA = collective.sharesOf(baseFundId, orga) + collective.sharesOf(baseFundId, alice)
+      + collective.sharesOf(baseFundId, bob);
+    assertEq(sharesA, fundA_.totalShares);
+    assertEq(fundA_.totalShares, 120); // alice 70 + bob 50
+
+    uint256 sharesB = collective.sharesOf(fundB, orga) + collective.sharesOf(fundB, alice);
+    assertEq(sharesB, fundB_.totalShares);
+    assertEq(fundB_.totalShares, 80);
+
+    // I2 — pool conservation: deposits + donations - withdrawals - executed amounts.
+    assertEq(fundA_.poolBalance, 100 + 50 + 25 - 60 - 23);
+    assertEq(fundB_.poolBalance, 80 + 20 - 20);
+
+    // I3 — singleton solvency, and no cross-fund bleed: fund A's disbursement and rage-quits
+    // never touched fund B's accounting.
+    assertEq(token.balanceOf(address(collective)), fundA_.poolBalance + fundB_.poolBalance);
+  }
+}

--- a/test/unit/GoalSavingCirclesUnit.t.sol
+++ b/test/unit/GoalSavingCirclesUnit.t.sol
@@ -1,0 +1,985 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {Initializable} from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import {ProxyAdmin} from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
+import {Test, Vm} from 'forge-std/Test.sol';
+
+import {GoalSavingCircles} from 'src/contracts/GoalSavingCircles.sol';
+import {IGoalSavingCircles} from 'src/interfaces/IGoalSavingCircles.sol';
+import {MockERC20} from 'test/mocks/MockERC20.sol';
+
+/**
+ * @notice Unit tests for {GoalSavingCircles}.
+ * @dev Actors: owner is the registry admin, alice is the goal owner (signs invites), bob and
+ *      carol are invited members, dave is a stranger with tokens (depositFor payer).
+ */
+contract GoalSavingCirclesUnit is Test {
+  GoalSavingCircles public goalCircles;
+  MockERC20 public token;
+
+  uint256 public constant GOAL_AMOUNT = 10 ether;
+  uint256 public constant DURATION = 30 days;
+  uint256 public constant START_BAL = 1000 ether;
+
+  address public owner;
+  address public alice;
+  uint256 internal _alicePrivateKey;
+  address public bob;
+  uint256 internal _bobPrivateKey;
+  address public carol;
+  address public dave;
+  address public beneficiary;
+
+  function setUp() public {
+    owner = makeAddr('owner');
+    (alice, _alicePrivateKey) = makeAddrAndKey('alice');
+    (bob, _bobPrivateKey) = makeAddrAndKey('bob');
+    carol = makeAddr('carol');
+    dave = makeAddr('dave');
+    beneficiary = makeAddr('beneficiary');
+
+    vm.startPrank(owner);
+    goalCircles = GoalSavingCircles(
+      address(
+        new TransparentUpgradeableProxy(
+          address(new GoalSavingCircles()),
+          address(new ProxyAdmin(owner)),
+          abi.encodeWithSelector(GoalSavingCircles.initialize.selector, owner)
+        )
+      )
+    );
+    token = new MockERC20('Test', 'TST');
+    goalCircles.setTokenAllowed(address(token), true);
+    vm.stopPrank();
+
+    address[4] memory holders = [alice, bob, carol, dave];
+    for (uint256 i = 0; i < holders.length; i++) {
+      token.mint(holders[i], START_BAL);
+      vm.prank(holders[i]);
+      token.approve(address(goalCircles), type(uint256).max);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  /// @dev EIP-712 'StacksInvite' v1 signature over Invite(uint256 id,uint256 nonce), with the
+  ///      goal contract as verifyingContract.
+  function _signGoalInvite(uint256 _id, uint256 _nonce, uint256 _signerKey) internal view returns (bytes memory) {
+    bytes32 structHash = keccak256(abi.encode(keccak256('Invite(uint256 id,uint256 nonce)'), _id, _nonce));
+    bytes32 domainSeparator = keccak256(
+      abi.encode(
+        keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
+        keccak256(bytes('StacksInvite')),
+        keccak256(bytes('1')),
+        block.chainid,
+        address(goalCircles)
+      )
+    );
+    bytes32 digest = keccak256(abi.encodePacked('\x19\x01', domainSeparator, structHash));
+    (uint8 v, bytes32 r, bytes32 s) = vm.sign(_signerKey, digest);
+    return abi.encodePacked(r, s, v);
+  }
+
+  /// @dev alice creates a goal for GOAL_AMOUNT due in DURATION.
+  function _createGoal(address _beneficiary) internal returns (uint256 _id) {
+    vm.prank(alice);
+    _id = goalCircles.create(address(token), GOAL_AMOUNT, block.timestamp + DURATION, _beneficiary);
+  }
+
+  /// @dev `_member` redeems an alice-signed invite for goal `_id`.
+  function _join(uint256 _id, address _member, uint256 _nonce) internal {
+    bytes memory signature = _signGoalInvite(_id, _nonce, _alicePrivateKey);
+    vm.prank(_member);
+    goalCircles.redeemInvite(_id, _nonce, signature);
+  }
+
+  /// @dev alice creates a goal and invites bob and carol.
+  function _createGoalWithMembers(address _beneficiary) internal returns (uint256 _id) {
+    _id = _createGoal(_beneficiary);
+    _join(_id, bob, 1);
+    _join(_id, carol, 2);
+  }
+
+  function _deposit(uint256 _id, address _who, uint256 _value) internal {
+    vm.prank(_who);
+    goalCircles.deposit(_id, _value);
+  }
+
+  /// @dev Assert no GoalReached event is present in the recorded logs.
+  function _assertNoGoalReached(Vm.Log[] memory _logs) internal pure {
+    for (uint256 i = 0; i < _logs.length; i++) {
+      assertTrue(_logs[i].topics[0] != keccak256('GoalReached(uint256,uint256)'), 'unexpected GoalReached');
+    }
+  }
+
+  // ==========================================================================
+  // Initialization & admin
+  // ==========================================================================
+
+  function test_InitializeSetsAdminOwner() public view {
+    assertEq(goalCircles.owner(), owner);
+  }
+
+  function test_InitializeWhenCalledTwice() public {
+    vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+    goalCircles.initialize(alice);
+  }
+
+  function test_ImplementationConstructorDisablesInitializers() public {
+    GoalSavingCircles implementation = new GoalSavingCircles();
+    vm.expectRevert(abi.encodeWithSelector(Initializable.InvalidInitialization.selector));
+    implementation.initialize(owner);
+  }
+
+  function test_SetTokenAllowedWhenCallerIsOwner() public {
+    address newToken = makeAddr('newToken');
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.TokenAllowed(newToken, true);
+    vm.prank(owner);
+    goalCircles.setTokenAllowed(newToken, true);
+
+    assertTrue(goalCircles.isTokenAllowed(newToken));
+  }
+
+  function test_SetTokenAllowedWhenCallerIsNotOwner() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(OwnableUpgradeable.OwnableUnauthorizedAccount.selector, alice));
+    goalCircles.setTokenAllowed(address(token), false);
+  }
+
+  function test_SetTokenAllowedWhenDisallowingToken() public {
+    uint256 id = _createGoal(beneficiary);
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.TokenAllowed(address(token), false);
+    vm.prank(owner);
+    goalCircles.setTokenAllowed(address(token), false);
+    assertFalse(goalCircles.isTokenAllowed(address(token)));
+
+    // The existing goal keeps working: deposits still accepted.
+    _deposit(id, alice, 1 ether);
+    assertEq(goalCircles.totalDeposited(id), 1 ether);
+
+    // But new goals with the disallowed token are rejected.
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.TokenNotAllowed.selector));
+    goalCircles.create(address(token), GOAL_AMOUNT, block.timestamp + DURATION, beneficiary);
+  }
+
+  // ==========================================================================
+  // create
+  // ==========================================================================
+
+  function test_CreateGoalWithValidParameters() public {
+    uint256 deadline = block.timestamp + DURATION;
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.GoalCreated(0, alice, address(token), GOAL_AMOUNT, deadline, beneficiary);
+    vm.prank(alice);
+    uint256 id = goalCircles.create(address(token), GOAL_AMOUNT, deadline, beneficiary);
+
+    assertEq(id, 0);
+    IGoalSavingCircles.Goal memory goal = goalCircles.getGoal(id);
+    assertEq(goal.owner, alice);
+    assertEq(goal.token, address(token));
+    assertEq(goal.beneficiary, beneficiary);
+    assertEq(goal.goalAmount, GOAL_AMOUNT);
+    assertEq(goal.deadline, deadline);
+
+    assertTrue(goalCircles.isMember(id, alice));
+    address[] memory members = goalCircles.getGoalMembers(id);
+    assertEq(members.length, 1);
+    assertEq(members[0], alice);
+    uint256[] memory ids = goalCircles.getMemberGoals(alice);
+    assertEq(ids.length, 1);
+    assertEq(ids[0], id);
+  }
+
+  function test_CreateGoalIncrementsNextId() public {
+    uint256 first = _createGoal(beneficiary);
+    uint256 second = _createGoal(address(0));
+
+    assertEq(first, 0);
+    assertEq(second, 1);
+    assertEq(goalCircles.nextId(), 2);
+  }
+
+  function test_CreateGoalWhenTokenNotAllowed() public {
+    MockERC20 otherToken = new MockERC20('Other', 'OTH');
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.TokenNotAllowed.selector));
+    goalCircles.create(address(otherToken), GOAL_AMOUNT, block.timestamp + DURATION, beneficiary);
+  }
+
+  function test_CreateGoalWhenGoalAmountIsZero() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.InvalidGoalAmount.selector));
+    goalCircles.create(address(token), 0, block.timestamp + DURATION, beneficiary);
+  }
+
+  function test_CreateGoalWhenDeadlineNotInFuture() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.InvalidDeadline.selector));
+    goalCircles.create(address(token), GOAL_AMOUNT, block.timestamp, beneficiary);
+  }
+
+  function test_CreateGoalWithZeroBeneficiary() public {
+    uint256 id = _createGoal(address(0));
+    assertEq(goalCircles.getGoal(id).beneficiary, address(0));
+  }
+
+  // ==========================================================================
+  // redeemInvite
+  // ==========================================================================
+
+  function test_RedeemInviteWithValidSignature() public {
+    uint256 id = _createGoal(beneficiary);
+    bytes memory signature = _signGoalInvite(id, 1, _alicePrivateKey);
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.InviteRedeemed(id, bob);
+    vm.prank(bob);
+    goalCircles.redeemInvite(id, 1, signature);
+
+    assertTrue(goalCircles.isMember(id, bob));
+    assertTrue(goalCircles.usedNonces(id, 1));
+    address[] memory members = goalCircles.getGoalMembers(id);
+    assertEq(members.length, 2);
+    assertEq(members[1], bob);
+    uint256[] memory ids = goalCircles.getMemberGoals(bob);
+    assertEq(ids.length, 1);
+    assertEq(ids[0], id);
+  }
+
+  function test_RedeemInviteWhenSignerIsNotGoalOwner() public {
+    uint256 id = _createGoal(beneficiary);
+    bytes memory signature = _signGoalInvite(id, 1, _bobPrivateKey);
+
+    vm.prank(carol);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.InvalidSigner.selector));
+    goalCircles.redeemInvite(id, 1, signature);
+  }
+
+  function test_RedeemInviteWhenNonceAlreadyUsed() public {
+    uint256 id = _createGoal(beneficiary);
+    _join(id, bob, 1);
+
+    bytes memory signature = _signGoalInvite(id, 1, _alicePrivateKey);
+    vm.prank(carol);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.InviteAlreadyUsed.selector));
+    goalCircles.redeemInvite(id, 1, signature);
+  }
+
+  function test_RedeemInviteWhenAlreadyMember() public {
+    uint256 id = _createGoal(beneficiary);
+    _join(id, bob, 1);
+
+    bytes memory signature = _signGoalInvite(id, 2, _alicePrivateKey);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.AlreadyMember.selector));
+    goalCircles.redeemInvite(id, 2, signature);
+  }
+
+  function test_RedeemInviteWhenGoalDoesNotExist() public {
+    bytes memory signature = _signGoalInvite(999, 1, _alicePrivateKey);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotFound.selector));
+    goalCircles.redeemInvite(999, 1, signature);
+  }
+
+  function test_RedeemInviteWhenDeadlinePassed() public {
+    uint256 id = _createGoal(beneficiary);
+    bytes memory signature = _signGoalInvite(id, 1, _alicePrivateKey);
+
+    vm.warp(block.timestamp + DURATION);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotOpen.selector));
+    goalCircles.redeemInvite(id, 1, signature);
+  }
+
+  function test_RedeemInviteWhenCancelled() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.prank(alice);
+    goalCircles.cancel(id);
+
+    bytes memory signature = _signGoalInvite(id, 1, _alicePrivateKey);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotOpen.selector));
+    goalCircles.redeemInvite(id, 1, signature);
+  }
+
+  function test_RedeemInviteWhenReleased() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    goalCircles.release(id);
+
+    bytes memory signature = _signGoalInvite(id, 1, _alicePrivateKey);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotOpen.selector));
+    goalCircles.redeemInvite(id, 1, signature);
+  }
+
+  function test_RedeemInviteAfterGoalReachedBeforeDeadline() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    assertTrue(goalCircles.goalReached(id));
+
+    _join(id, bob, 1);
+    assertTrue(goalCircles.isMember(id, bob));
+  }
+
+  function test_RedeemInviteNonceIsScopedPerGoal() public {
+    uint256 first = _createGoal(beneficiary);
+    uint256 second = _createGoal(address(0));
+
+    _join(first, bob, 7);
+    _join(second, bob, 7);
+
+    assertTrue(goalCircles.usedNonces(first, 7));
+    assertTrue(goalCircles.usedNonces(second, 7));
+    assertTrue(goalCircles.isMember(first, bob));
+    assertTrue(goalCircles.isMember(second, bob));
+  }
+
+  // ==========================================================================
+  // deposit / depositFor
+  // ==========================================================================
+
+  function test_DepositWhenCallerIsMember() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.FundsDeposited(id, bob, 1 ether);
+    _deposit(id, bob, 1 ether);
+
+    assertEq(goalCircles.contributions(id, bob), 1 ether);
+    assertEq(goalCircles.totalDeposited(id), 1 ether);
+    assertEq(token.balanceOf(address(goalCircles)), 1 ether);
+    assertEq(token.balanceOf(bob), START_BAL - 1 ether);
+  }
+
+  function test_DepositWhenCallerIsNotMember() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotMember.selector));
+    goalCircles.deposit(id, 1 ether);
+  }
+
+  function test_DepositWhenValueIsZero() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.InvalidDeposit.selector));
+    goalCircles.deposit(id, 0);
+  }
+
+  function test_DepositMultipleTimesAccumulates() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, 1 ether);
+    _deposit(id, alice, 2 ether);
+    _deposit(id, alice, 3 ether);
+
+    assertEq(goalCircles.contributions(id, alice), 6 ether);
+    assertEq(goalCircles.totalDeposited(id), 6 ether);
+  }
+
+  function test_DepositWhenGoalDoesNotExist() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotFound.selector));
+    goalCircles.deposit(999, 1 ether);
+  }
+
+  function test_DepositWhenDeadlinePassed() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.warp(block.timestamp + DURATION + 1);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotOpen.selector));
+    goalCircles.deposit(id, 1 ether);
+  }
+
+  function test_DepositAtExactDeadlineTimestamp() public {
+    uint256 deadline = block.timestamp + DURATION;
+    uint256 id = _createGoal(beneficiary);
+    vm.warp(deadline);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotOpen.selector));
+    goalCircles.deposit(id, 1 ether);
+  }
+
+  function test_DepositWhenCancelled() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.prank(alice);
+    goalCircles.cancel(id);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotOpen.selector));
+    goalCircles.deposit(id, 1 ether);
+  }
+
+  function test_DepositWhenReleased() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    goalCircles.release(id);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotOpen.selector));
+    goalCircles.deposit(id, 1 ether);
+  }
+
+  function test_DepositCrossingGoalEmitsGoalReachedOnce() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT - 1 ether);
+
+    // The crossing deposit emits GoalReached (with the pot size) then FundsDeposited.
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.GoalReached(id, GOAL_AMOUNT + 1 ether);
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.FundsDeposited(id, bob, 2 ether);
+    _deposit(id, bob, 2 ether);
+    assertTrue(goalCircles.goalReached(id));
+
+    // A later deposit emits no second GoalReached.
+    vm.recordLogs();
+    _deposit(id, carol, 1 ether);
+    _assertNoGoalReached(vm.getRecordedLogs());
+  }
+
+  function test_DepositOvershootAllowed() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT + 5 ether);
+
+    assertEq(goalCircles.totalDeposited(id), GOAL_AMOUNT + 5 ether);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Funded);
+  }
+
+  function test_DepositAfterGoalReachedBeforeDeadline() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+
+    _deposit(id, bob, 1 ether);
+    assertEq(goalCircles.totalDeposited(id), GOAL_AMOUNT + 1 ether);
+  }
+
+  function test_DepositForCreditsMemberAndPullsFromCaller() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.FundsDeposited(id, bob, 3 ether);
+    vm.prank(dave);
+    goalCircles.depositFor(id, bob, 3 ether);
+
+    assertEq(token.balanceOf(dave), START_BAL - 3 ether);
+    assertEq(token.balanceOf(bob), START_BAL);
+    assertEq(goalCircles.contributions(id, bob), 3 ether);
+    assertEq(goalCircles.contributions(id, dave), 0);
+    assertEq(goalCircles.totalDeposited(id), 3 ether);
+  }
+
+  function test_DepositForWhenTargetIsNotMember() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotMember.selector));
+    goalCircles.depositFor(id, bob, 1 ether);
+  }
+
+  // ==========================================================================
+  // withdraw
+  // ==========================================================================
+
+  function test_WithdrawWhenGoalFailed() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+    _deposit(id, bob, 4 ether);
+    vm.warp(block.timestamp + DURATION);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Failed);
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.FundsWithdrawn(id, bob, 4 ether);
+    vm.prank(bob);
+    goalCircles.withdraw(id);
+
+    assertEq(goalCircles.contributions(id, bob), 0);
+    assertEq(goalCircles.totalDeposited(id), 0);
+    assertEq(token.balanceOf(bob), START_BAL);
+  }
+
+  function test_WithdrawWhenGoalCancelled() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+    _deposit(id, carol, 2 ether);
+    vm.prank(alice);
+    goalCircles.cancel(id);
+
+    vm.prank(carol);
+    goalCircles.withdraw(id);
+
+    assertEq(goalCircles.contributions(id, carol), 0);
+    assertEq(token.balanceOf(carol), START_BAL);
+  }
+
+  function test_WithdrawWhenFundedWithoutBeneficiary() public {
+    uint256 id = _createGoalWithMembers(address(0));
+    _deposit(id, alice, GOAL_AMOUNT);
+    _deposit(id, bob, 1 ether);
+
+    vm.prank(bob);
+    goalCircles.withdraw(id);
+
+    assertEq(token.balanceOf(bob), START_BAL);
+    assertEq(goalCircles.totalDeposited(id), GOAL_AMOUNT);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Funded);
+  }
+
+  function test_WithdrawWhenFundedWithBeneficiary() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotWithdrawable.selector));
+    goalCircles.withdraw(id);
+  }
+
+  function test_WithdrawWhenFunding() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, 1 ether);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotWithdrawable.selector));
+    goalCircles.withdraw(id);
+  }
+
+  function test_WithdrawWhenReleased() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    goalCircles.release(id);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotWithdrawable.selector));
+    goalCircles.withdraw(id);
+  }
+
+  function test_WithdrawWhenGoalDoesNotExist() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotFound.selector));
+    goalCircles.withdraw(999);
+  }
+
+  function test_WithdrawWhenNothingToWithdraw() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+    vm.warp(block.timestamp + DURATION);
+
+    // Member with a zero contribution.
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NothingToWithdraw.selector));
+    goalCircles.withdraw(id);
+
+    // Non-members always have zero contribution too.
+    vm.prank(dave);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NothingToWithdraw.selector));
+    goalCircles.withdraw(id);
+  }
+
+  function test_WithdrawTwiceReverts() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, 1 ether);
+    vm.warp(block.timestamp + DURATION);
+
+    vm.prank(alice);
+    goalCircles.withdraw(id);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NothingToWithdraw.selector));
+    goalCircles.withdraw(id);
+  }
+
+  function test_WithdrawByAllMembersDrainsPot() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+    _deposit(id, alice, 1 ether);
+    _deposit(id, bob, 2 ether);
+    _deposit(id, carol, 3 ether);
+    vm.warp(block.timestamp + DURATION);
+
+    address[3] memory members = [alice, bob, carol];
+    for (uint256 i = 0; i < members.length; i++) {
+      vm.prank(members[i]);
+      goalCircles.withdraw(id);
+      assertEq(token.balanceOf(members[i]), START_BAL);
+    }
+
+    assertEq(goalCircles.totalDeposited(id), 0);
+    assertEq(token.balanceOf(address(goalCircles)), 0);
+  }
+
+  function test_WithdrawThenRedepositWhileFundedWithoutBeneficiary() public {
+    uint256 id = _createGoal(address(0));
+    _deposit(id, alice, GOAL_AMOUNT);
+    assertTrue(goalCircles.goalReached(id));
+
+    vm.prank(alice);
+    goalCircles.withdraw(id);
+    assertEq(goalCircles.totalDeposited(id), 0);
+    assertTrue(goalCircles.goalReached(id)); // latch persists below goalAmount
+
+    _deposit(id, alice, 1 ether);
+    assertEq(goalCircles.contributions(id, alice), 1 ether);
+    assertEq(goalCircles.totalDeposited(id), 1 ether);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Funded);
+  }
+
+  // ==========================================================================
+  // release
+  // ==========================================================================
+
+  function test_ReleaseWhenFundedWithBeneficiary() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT + 2 ether); // overshoot travels with the pot
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.GoalReleased(id, beneficiary, GOAL_AMOUNT + 2 ether);
+    goalCircles.release(id);
+
+    assertTrue(goalCircles.released(id));
+    assertEq(goalCircles.totalDeposited(id), 0);
+    assertEq(token.balanceOf(beneficiary), GOAL_AMOUNT + 2 ether);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Released);
+    // Contributions persist as historical receipts.
+    assertEq(goalCircles.contributions(id, alice), GOAL_AMOUNT + 2 ether);
+  }
+
+  function test_ReleaseByNonMember() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+
+    vm.prank(dave);
+    goalCircles.release(id);
+    assertEq(token.balanceOf(beneficiary), GOAL_AMOUNT);
+  }
+
+  function test_ReleaseAfterDeadlineWhenFunded() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    vm.warp(block.timestamp + DURATION + 365 days);
+
+    goalCircles.release(id);
+    assertEq(token.balanceOf(beneficiary), GOAL_AMOUNT);
+  }
+
+  function test_ReleaseWhenFunding() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, 1 ether);
+
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotReleasable.selector));
+    goalCircles.release(id);
+  }
+
+  function test_ReleaseWhenFailed() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, 1 ether);
+    vm.warp(block.timestamp + DURATION);
+
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotReleasable.selector));
+    goalCircles.release(id);
+  }
+
+  function test_ReleaseWhenCancelled() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.prank(alice);
+    goalCircles.cancel(id);
+
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotReleasable.selector));
+    goalCircles.release(id);
+  }
+
+  function test_ReleaseWhenBeneficiaryIsZero() public {
+    uint256 id = _createGoal(address(0));
+    _deposit(id, alice, GOAL_AMOUNT);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Funded);
+
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotReleasable.selector));
+    goalCircles.release(id);
+  }
+
+  function test_ReleaseTwiceReverts() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    goalCircles.release(id);
+
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotReleasable.selector));
+    goalCircles.release(id);
+  }
+
+  function test_ReleaseWhenGoalDoesNotExist() public {
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotFound.selector));
+    goalCircles.release(999);
+  }
+
+  // ==========================================================================
+  // cancel
+  // ==========================================================================
+
+  function test_CancelWhenCallerIsGoalOwnerDuringFunding() public {
+    uint256 id = _createGoal(beneficiary);
+
+    vm.expectEmit(true, true, true, true);
+    emit IGoalSavingCircles.GoalCancelled(id);
+    vm.prank(alice);
+    goalCircles.cancel(id);
+
+    assertTrue(goalCircles.cancelled(id));
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Cancelled);
+  }
+
+  function test_CancelWhenCallerIsNotGoalOwner() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+
+    vm.prank(bob);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotOwner.selector));
+    goalCircles.cancel(id);
+
+    // The registry admin is not the goal owner either.
+    vm.prank(owner);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotOwner.selector));
+    goalCircles.cancel(id);
+  }
+
+  function test_CancelWhenFunded() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotCancellable.selector));
+    goalCircles.cancel(id);
+  }
+
+  function test_CancelWhenFailed() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.warp(block.timestamp + DURATION);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotCancellable.selector));
+    goalCircles.cancel(id);
+  }
+
+  function test_CancelWhenAlreadyCancelled() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.prank(alice);
+    goalCircles.cancel(id);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.NotCancellable.selector));
+    goalCircles.cancel(id);
+  }
+
+  function test_CancelWhenGoalDoesNotExist() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotFound.selector));
+    goalCircles.cancel(999);
+  }
+
+  function test_CancelThenWithdrawRefundsEveryMemberExactly() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+    _deposit(id, alice, 1 ether);
+    _deposit(id, bob, 2 ether);
+    _deposit(id, carol, 3 ether);
+
+    vm.prank(alice);
+    goalCircles.cancel(id);
+
+    address[3] memory members = [alice, bob, carol];
+    for (uint256 i = 0; i < members.length; i++) {
+      vm.prank(members[i]);
+      goalCircles.withdraw(id);
+      assertEq(token.balanceOf(members[i]), START_BAL);
+    }
+    assertEq(token.balanceOf(address(goalCircles)), 0);
+  }
+
+  // ==========================================================================
+  // goalState & views
+  // ==========================================================================
+
+  function test_GoalStateWhenFunding() public {
+    uint256 id = _createGoal(beneficiary);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Funding);
+  }
+
+  function test_GoalStateWhenFunded() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Funded);
+  }
+
+  function test_GoalStateWhenFailedAfterDeadline() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, 1 ether);
+    vm.warp(block.timestamp + DURATION + 1);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Failed);
+  }
+
+  function test_GoalStateAtExactDeadlineIsFailed() public {
+    uint256 deadline = block.timestamp + DURATION;
+    uint256 id = _createGoal(beneficiary);
+    vm.warp(deadline);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Failed);
+  }
+
+  function test_GoalStateWhenCancelled() public {
+    uint256 id = _createGoal(beneficiary);
+    vm.prank(alice);
+    goalCircles.cancel(id);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Cancelled);
+  }
+
+  function test_GoalStateWhenReleased() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    goalCircles.release(id);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Released);
+  }
+
+  function test_GoalStateFundedPersistsAfterDeadline() public {
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT);
+    vm.warp(block.timestamp + DURATION + 365 days);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Funded);
+  }
+
+  function test_GoalStateFundedPersistsAfterWithdrawalsBelowGoal() public {
+    uint256 id = _createGoal(address(0));
+    _deposit(id, alice, GOAL_AMOUNT);
+
+    vm.prank(alice);
+    goalCircles.withdraw(id);
+
+    assertEq(goalCircles.totalDeposited(id), 0);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Funded);
+  }
+
+  function test_GoalStateWhenGoalDoesNotExist() public {
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotFound.selector));
+    goalCircles.goalState(999);
+  }
+
+  function test_GetGoalReturnsConfig() public {
+    uint256 deadline = block.timestamp + DURATION;
+    uint256 id = _createGoal(beneficiary);
+
+    IGoalSavingCircles.Goal memory goal = goalCircles.getGoal(id);
+    assertEq(goal.owner, alice);
+    assertEq(goal.token, address(token));
+    assertEq(goal.beneficiary, beneficiary);
+    assertEq(goal.goalAmount, GOAL_AMOUNT);
+    assertEq(goal.deadline, deadline);
+  }
+
+  function test_GetGoalWhenGoalDoesNotExist() public {
+    vm.expectRevert(abi.encodeWithSelector(IGoalSavingCircles.GoalNotFound.selector));
+    goalCircles.getGoal(999);
+  }
+
+  function test_GetGoalMembersReturnsRoster() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+
+    address[] memory members = goalCircles.getGoalMembers(id);
+    assertEq(members.length, 3);
+    assertEq(members[0], alice); // owner first
+    assertEq(members[1], bob); // then invite-redemption order
+    assertEq(members[2], carol);
+  }
+
+  function test_GetMemberGoalsReturnsIds() public {
+    uint256 first = _createGoal(beneficiary);
+    uint256 second = _createGoal(address(0));
+    _join(first, bob, 1);
+    _join(second, bob, 1);
+
+    uint256[] memory bobIds = goalCircles.getMemberGoals(bob);
+    assertEq(bobIds.length, 2);
+    assertEq(bobIds[0], first);
+    assertEq(bobIds[1], second);
+
+    uint256[] memory aliceIds = goalCircles.getMemberGoals(alice);
+    assertEq(aliceIds.length, 2);
+  }
+
+  function test_GetMemberContributionsAlignedArrays() public {
+    uint256 id = _createGoalWithMembers(beneficiary);
+    _deposit(id, alice, 1 ether);
+    _deposit(id, bob, 2 ether);
+
+    (address[] memory members, uint256[] memory amounts) = goalCircles.getMemberContributions(id);
+    assertEq(members.length, 3);
+    assertEq(amounts.length, 3);
+    assertEq(members[0], alice);
+    assertEq(amounts[0], 1 ether);
+    assertEq(members[1], bob);
+    assertEq(amounts[1], 2 ether);
+    assertEq(members[2], carol);
+    assertEq(amounts[2], 0);
+  }
+
+  function test_IsTokenAllowedReflectsAllowlist() public {
+    assertTrue(goalCircles.isTokenAllowed(address(token)));
+    assertFalse(goalCircles.isTokenAllowed(makeAddr('unknownToken')));
+
+    vm.prank(owner);
+    goalCircles.setTokenAllowed(address(token), false);
+    assertFalse(goalCircles.isTokenAllowed(address(token)));
+  }
+
+  // ==========================================================================
+  // Fuzz
+  // ==========================================================================
+
+  function testFuzz_DepositWithdrawConservation(uint256[] memory _amounts) public {
+    vm.assume(_amounts.length > 0);
+
+    // A goal too big to ever reach, so the deadline forces Failed.
+    vm.prank(alice);
+    uint256 id = goalCircles.create(address(token), 1e36, block.timestamp + DURATION, beneficiary);
+    _join(id, bob, 1);
+    _join(id, carol, 2);
+
+    address[3] memory members = [alice, bob, carol];
+    uint256 count = _amounts.length < 8 ? _amounts.length : 8;
+    for (uint256 i = 0; i < count; i++) {
+      uint256 amount = bound(_amounts[i], 1, 100 ether);
+      _deposit(id, members[i % 3], amount);
+    }
+
+    vm.warp(block.timestamp + DURATION);
+    assertTrue(goalCircles.goalState(id) == IGoalSavingCircles.GoalState.Failed);
+
+    for (uint256 i = 0; i < members.length; i++) {
+      if (goalCircles.contributions(id, members[i]) > 0) {
+        vm.prank(members[i]);
+        goalCircles.withdraw(id);
+      }
+      assertEq(token.balanceOf(members[i]), START_BAL, 'member made whole');
+    }
+
+    assertEq(goalCircles.totalDeposited(id), 0);
+    assertEq(token.balanceOf(address(goalCircles)), 0, 'contract drained');
+  }
+
+  function testFuzz_ReleasePaysExactPot(uint256 _overshoot) public {
+    _overshoot = bound(_overshoot, 0, 500 ether);
+
+    uint256 id = _createGoal(beneficiary);
+    _deposit(id, alice, GOAL_AMOUNT + _overshoot);
+
+    uint256 pot = goalCircles.totalDeposited(id);
+    assertEq(pot, GOAL_AMOUNT + _overshoot);
+
+    goalCircles.release(id);
+
+    assertEq(token.balanceOf(beneficiary), pot, 'beneficiary paid the exact pot');
+    assertEq(goalCircles.totalDeposited(id), 0);
+    assertEq(token.balanceOf(address(goalCircles)), 0);
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds **three new stack types** alongside the existing ROSCA (`SavingCircles`), completing the family of community savings primitives:

| Contract | Stack type | One-liner |
|---|---|---|
| `AccumulatingSavingCircles` | **ASCA** (Accumulating Savings & Credit Association) | Members deposit *whatever amount, whenever*; each earns a credit line as a percentage of their own savings, borrows from the pool, and repays within a configured number of periods with optional interest — interest streams pro-rata to savers. |
| `GoalSavingCircles` | **Goal savings** | A group saves toward a target by a deadline. Funds are locked while funding (the commitment device); on success the pot releases to a pre-agreed beneficiary — or, with no beneficiary, everyone reclaims exactly their own contributions. On failure/cancel: full refunds. |
| `CollectiveFundCircles` | **Collective fund** (white-label communal pot) | A community saves together and *spends together*: flexible deposits, rage-quit anytime for a pro-rata share, one-member-one-vote disbursement proposals with a snapshotted electorate, permissionless execution. Fund name lives on-chain so any frontend can white-label a fund from just `?f=<id>`. |

Together with #183 (the chit fund / reverse-auction ROSCA), this covers ROSCA + Chit + ASCA + Goal + Collective.

## Design

All three follow the house pattern established by `SavingCircles`:

- Singleton registry keyed by `uint256 id`, upgradeable (`OwnableUpgradeable` + `ReentrancyGuardUpgradeable` + `EIP712Upgradeable`), `_disableInitializers()` constructor, `initialize(address owner)` behind a `TransparentUpgradeableProxy`.
- **Same EIP-712 `StacksInvite` domain** and `Invite(uint256 id,uint256 nonce)` typehash as `SavingCircles` — the app-stacks invite flow ports over unchanged (only `verifyingContract` differs).
- Admin ERC20 allowlist (`setTokenAllowed`), SafeERC20, custom errors only, checks-effects-interactions, `nonReentrant` on every token-moving external, interface-first with full NatSpec and `@inheritdoc`.
- Internal per-fund cash ledgers (never `balanceOf` for logic) — funds in the singleton cannot bleed into each other.

### Safety highlights

- **ASCA:** credit lines are capped at 100% of the borrower's own savings (`borrowLimitBps <= 10_000`), so every loan is fully self-collateralized — a defaulter can only ever burn their own savings, never another member's principal. Interest accrual is simple, per whole period, capped at the due date; overdue loans are **permissionlessly liquidatable** (pure ledger reallocation, no token movement). Interest distribution uses a MasterChef-style per-share accumulator (floor rounding, dust stays in the pool).
- **Goal:** no division anywhere — all accounting is exact addition/subtraction, so conservation is an equality. `goalReached`/`cancelled`/`released` are one-way latches; release is permissionless once funded.
- **Collective:** share conservation (`Σ sharesOf == totalShares`), pro-rata rage-quit maths round down in favor of the pool, the last exiter sweeps dust exactly. Proposals snapshot the electorate via an append-only member list (`memberIndex < electorate`, O(1) per proposal), require `ceil(electorate × thresholdBps / 10_000)` yes-votes, auto-pass early, and expire after one extra voting period. **Rage-quit is never blocked by any proposal state** — a member's deposit is never hostage to a vote they lost.

Design notes for each contract are in `docs/` (mechanism, invariants, judged decisions), mirroring the pattern from #183.

## Testing

```
forge test    # 437 passed (168 pre-existing + 269 new), 0 failed
```

- `AccumulatingSavingCirclesUnit` — 88 tests, 100% branch coverage (40/40)
- `GoalSavingCirclesUnit` — 80 tests, 100% branch coverage (20/20)
- `CollectiveFundCirclesUnit` — 101 tests, 100% branch coverage (37/37)

Each suite covers every revert branch, every state transition, event emissions, boundary timestamps, rounding/dust behavior, and cross-cutting conservation checks (including a two-funds-one-token no-bleed test). `forge fmt` + `solhint` clean.

The implementation went through an adversarial review pass (independent exploit-hunting and spec-conformance lenses per contract, findings PoC-verified against the code): **no confirmed findings**.

## Deployment / CI wiring

- `script/Common.sol` `_deployContracts` now deploys all three behind their own transparent proxies (existing return value unchanged, so `IntegrationBase` keeps working).
- `.github/upgrades.json`: three new entries for upgrade-safety validation.

## Scope (v1) & follow-ups

Ships the core mechanics above. Documented extensions (in `docs/`): loan top-ups & third-party repay + Chainlink liquidation satellite (ASCA), open-join & yield-bearing goals (Goal), member removal, weighted voting, earmarked donations, ERC-7572 `contractURI` metadata (Collective), viewer-lens getters and fuzz/invariant suites as fast-follows.

Frontend support for all three types is in the companion PR on `app-stacks`.
